### PR TITLE
Extend thesis toolkit with convergence and comparison plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+arnab_repo/
+*.pyc
+*.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+# Master Thesis: Mechanism Reduction Toolkit
+
+This project provides a Python implementation for reducing chemical reaction mechanisms using graph algorithms, metaheuristics, and neural networks.  It reproduces much of the functionality of the original MATLAB framework found in the `MECH` folder and integrates portions of Arnab's GA project.
+
+## Project Layout
+
+```
+/data               Example mechanism files
+/graphs             Exported graphs in GraphML
+/gnn                Graph neural network models
+/mechanism          Mechanism parsing and editing utilities
+/metaheuristics     GA, ABC, Bees and Branch-and-Bound algorithms
+/reactor            Reactor models using Cantera
+/testing            Command line testing scripts
+/visualizations     Plotting utilities
+/results            Output data and figures
+```
+
+## Example Usage
+
+Run the full testing pipeline:
+
+```bash
+python -m testing.run_tests --mechanism data/gri30.yaml --out results
+```
+
+This command executes all metaheuristics, compares reduced mechanisms to the full one and stores metrics and plots in the `results` folder.
+
+Generated figures include convergence curves for each metaheuristic and
+comparison bar charts. Example plots are shown below:
+
+![Convergence](results/convergence.png)
+![Comparison](results/comparison.png)
+
+## Installation
+
+Required packages are listed below.  Install with `pip`:
+
+```
+pip install cantera numpy scipy pandas matplotlib networkx torch torch_geometric
+```
+
+## Modules
+
+- **mechanism** – parse CTI/CK mechanisms using Cantera and remove species/reactions.
+- **graph** – construct species–reaction graphs and export in GraphML format.
+- **reactor** – batch, piston and network reactor solvers and 1-D flames.
+- **progress_variable** – compute progress variables from reactor results.
+- **metrics** – distance metrics for comparing reactor runs.
+- **timescales** – basic timescale analysis.
+- **metaheuristics** – GA, ABC, Bees and Branch-and-Bound algorithms for mechanism reduction.
+- **gnn** – graph neural network models (GCN and GAT) for scoring species.
+- **testing** – scripts to run example simulations and measure reduction errors.
+
+## Thesis Pipeline
+1. Load a mechanism using `mechanism.Mechanism`.
+2. Build the species graph with `graph.construction.build_species_graph`.
+3. Run reactor simulations with modules from `reactor`.
+4. Compute progress variables and errors.
+5. Optimise species selection via GA, ABC, Bees or BnB metaheuristics.
+6. Optionally train a GNN model to predict species importance.
+7. Compute timescales and distance metrics for evaluation.
+
+All results and plots should be written into the `results` and `visualizations` folders.

--- a/data/gri30.xml
+++ b/data/gri30.xml
@@ -1,0 +1,6213 @@
+<?xml version="1.0"?>
+<ctml>
+  <validate reactions="yes" species="yes"/>
+
+  <!-- phase gri30     -->
+  <phase dim="3" id="gri30">
+    <elementArray datasrc="elements.xml">O  H  C  N  Ar </elementArray>
+    <speciesArray datasrc="#species_data">
+      H2  H  O  O2  OH  H2O  HO2  H2O2  C  CH 
+      CH2  CH2(S)  CH3  CH4  CO  CO2  HCO  CH2O  CH2OH  CH3O 
+      CH3OH  C2H  C2H2  C2H3  C2H4  C2H5  C2H6  HCCO  CH2CO  HCCOH 
+      N  NH  NH2  NH3  NNH  NO  NO2  N2O  HNO  CN 
+      HCN  H2CN  HCNN  HCNO  HOCN  HNCO  NCO  N2  AR  C3H7 
+      C3H8  CH2CHO  CH3CHO </speciesArray>
+    <reactionArray datasrc="#reaction_data"/>
+    <state>
+      <temperature units="K">300.0</temperature>
+      <pressure units="Pa">101325.0</pressure>
+    </state>
+    <thermo model="IdealGas"/>
+    <kinetics model="GasKinetics"/>
+    <transport model="None"/>
+  </phase>
+
+  <!-- phase gri30_mix     -->
+  <phase dim="3" id="gri30_mix">
+    <elementArray datasrc="elements.xml">O  H  C  N  Ar </elementArray>
+    <speciesArray datasrc="#species_data">
+      H2  H  O  O2  OH  H2O  HO2  H2O2  C  CH 
+      CH2  CH2(S)  CH3  CH4  CO  CO2  HCO  CH2O  CH2OH  CH3O 
+      CH3OH  C2H  C2H2  C2H3  C2H4  C2H5  C2H6  HCCO  CH2CO  HCCOH 
+      N  NH  NH2  NH3  NNH  NO  NO2  N2O  HNO  CN 
+      HCN  H2CN  HCNN  HCNO  HOCN  HNCO  NCO  N2  AR  C3H7 
+      C3H8  CH2CHO  CH3CHO </speciesArray>
+    <reactionArray datasrc="#reaction_data"/>
+    <state>
+      <temperature units="K">300.0</temperature>
+      <pressure units="Pa">101325.0</pressure>
+    </state>
+    <thermo model="IdealGas"/>
+    <kinetics model="GasKinetics"/>
+    <transport model="Mix"/>
+  </phase>
+
+  <!-- phase gri30_multi     -->
+  <phase dim="3" id="gri30_multi">
+    <elementArray datasrc="elements.xml">O  H  C  N  Ar </elementArray>
+    <speciesArray datasrc="#species_data">
+      H2  H  O  O2  OH  H2O  HO2  H2O2  C  CH 
+      CH2  CH2(S)  CH3  CH4  CO  CO2  HCO  CH2O  CH2OH  CH3O 
+      CH3OH  C2H  C2H2  C2H3  C2H4  C2H5  C2H6  HCCO  CH2CO  HCCOH 
+      N  NH  NH2  NH3  NNH  NO  NO2  N2O  HNO  CN 
+      HCN  H2CN  HCNN  HCNO  HOCN  HNCO  NCO  N2  AR  C3H7 
+      C3H8  CH2CHO  CH3CHO </speciesArray>
+    <reactionArray datasrc="#reaction_data"/>
+    <state>
+      <temperature units="K">300.0</temperature>
+      <pressure units="Pa">101325.0</pressure>
+    </state>
+    <thermo model="IdealGas"/>
+    <kinetics model="GasKinetics"/>
+    <transport model="Multi"/>
+  </phase>
+
+  <!-- species definitions     -->
+  <speciesData id="species_data">
+
+    <!-- species H2    -->
+    <species name="H2">
+      <atomArray>H:2 </atomArray>
+      <note>TPIS78</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.344331120E+00,   7.980520750E-03,  -1.947815100E-05,   2.015720940E-08, 
+             -7.376117610E-12,  -9.179351730E+02,   6.830102380E-01</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.337279200E+00,  -4.940247310E-05,   4.994567780E-07,  -1.795663940E-10, 
+             2.002553760E-14,  -9.501589220E+02,  -3.205023310E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">38.000</LJ_welldepth>
+        <LJ_diameter units="A">2.920</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.790</polarizability>
+        <rotRelax>280.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species H    -->
+    <species name="H">
+      <atomArray>H:1 </atomArray>
+      <note>L 7/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.500000000E+00,   7.053328190E-13,  -1.995919640E-15,   2.300816320E-18, 
+             -9.277323320E-22,   2.547365990E+04,  -4.466828530E-01</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.500000010E+00,  -2.308429730E-11,   1.615619480E-14,  -4.735152350E-18, 
+             4.981973570E-22,   2.547365990E+04,  -4.466829140E-01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">atom</string>
+        <LJ_welldepth units="K">145.000</LJ_welldepth>
+        <LJ_diameter units="A">2.050</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species O    -->
+    <species name="O">
+      <atomArray>O:1 </atomArray>
+      <note>L 1/90</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.168267100E+00,  -3.279318840E-03,   6.643063960E-06,  -6.128066240E-09, 
+             2.112659710E-12,   2.912225920E+04,   2.051933460E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.569420780E+00,  -8.597411370E-05,   4.194845890E-08,  -1.001777990E-11, 
+             1.228336910E-15,   2.921757910E+04,   4.784338640E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">atom</string>
+        <LJ_welldepth units="K">80.000</LJ_welldepth>
+        <LJ_diameter units="A">2.750</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species O2    -->
+    <species name="O2">
+      <atomArray>O:2 </atomArray>
+      <note>TPIS89</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.782456360E+00,  -2.996734160E-03,   9.847302010E-06,  -9.681295090E-09, 
+             3.243728370E-12,  -1.063943560E+03,   3.657675730E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.282537840E+00,   1.483087540E-03,  -7.579666690E-07,   2.094705550E-10, 
+             -2.167177940E-14,  -1.088457720E+03,   5.453231290E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">107.400</LJ_welldepth>
+        <LJ_diameter units="A">3.460</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">1.600</polarizability>
+        <rotRelax>3.800</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species OH    -->
+    <species name="OH">
+      <atomArray>H:1 O:1 </atomArray>
+      <note>RUS 78</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.992015430E+00,  -2.401317520E-03,   4.617938410E-06,  -3.881133330E-09, 
+             1.364114700E-12,   3.615080560E+03,  -1.039254580E-01</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.092887670E+00,   5.484297160E-04,   1.265052280E-07,  -8.794615560E-11, 
+             1.174123760E-14,   3.858657000E+03,   4.476696100E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">80.000</LJ_welldepth>
+        <LJ_diameter units="A">2.750</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species H2O    -->
+    <species name="H2O">
+      <atomArray>H:2 O:1 </atomArray>
+      <note>L 8/89</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.198640560E+00,  -2.036434100E-03,   6.520402110E-06,  -5.487970620E-09, 
+             1.771978170E-12,  -3.029372670E+04,  -8.490322080E-01</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.033992490E+00,   2.176918040E-03,  -1.640725180E-07,  -9.704198700E-11, 
+             1.682009920E-14,  -3.000429710E+04,   4.966770100E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">572.400</LJ_welldepth>
+        <LJ_diameter units="A">2.600</LJ_diameter>
+        <dipoleMoment units="Debye">1.840</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>4.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HO2    -->
+    <species name="HO2">
+      <atomArray>H:1 O:2 </atomArray>
+      <note>L 5/89</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.301798010E+00,  -4.749120510E-03,   2.115828910E-05,  -2.427638940E-08, 
+             9.292251240E-12,   2.948080400E+02,   3.716662450E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.017210900E+00,   2.239820130E-03,  -6.336581500E-07,   1.142463700E-10, 
+             -1.079085350E-14,   1.118567130E+02,   3.785102150E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">107.400</LJ_welldepth>
+        <LJ_diameter units="A">3.460</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species H2O2    -->
+    <species name="H2O2">
+      <atomArray>H:2 O:2 </atomArray>
+      <note>L 7/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.276112690E+00,  -5.428224170E-04,   1.673357010E-05,  -2.157708130E-08, 
+             8.624543630E-12,  -1.770258210E+04,   3.435050740E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.165002850E+00,   4.908316940E-03,  -1.901392250E-06,   3.711859860E-10, 
+             -2.879083050E-14,  -1.786178770E+04,   2.916156620E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">107.400</LJ_welldepth>
+        <LJ_diameter units="A">3.460</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>3.800</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C    -->
+    <species name="C">
+      <atomArray>C:1 </atomArray>
+      <note>L11/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.554239550E+00,  -3.215377240E-04,   7.337922450E-07,  -7.322348890E-10, 
+             2.665214460E-13,   8.544388320E+04,   4.531308480E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.492668880E+00,   4.798892840E-05,  -7.243350200E-08,   3.742910290E-11, 
+             -4.872778930E-15,   8.545129530E+04,   4.801503730E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">atom</string>
+        <LJ_welldepth units="K">71.400</LJ_welldepth>
+        <LJ_diameter units="A">3.300</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH    -->
+    <species name="CH">
+      <atomArray>H:1 C:1 </atomArray>
+      <note>TPIS79</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.489816650E+00,   3.238355410E-04,  -1.688990650E-06,   3.162173270E-09, 
+             -1.406090670E-12,   7.079729340E+04,   2.084011080E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.878464730E+00,   9.709136810E-04,   1.444456550E-07,  -1.306878490E-10, 
+             1.760793830E-14,   7.101243640E+04,   5.484979990E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">80.000</LJ_welldepth>
+        <LJ_diameter units="A">2.750</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH2    -->
+    <species name="CH2">
+      <atomArray>H:2 C:1 </atomArray>
+      <note>L S/93</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.762678670E+00,   9.688721430E-04,   2.794898410E-06,  -3.850911530E-09, 
+             1.687417190E-12,   4.600404010E+04,   1.562531850E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.874101130E+00,   3.656392920E-03,  -1.408945970E-06,   2.601795490E-10, 
+             -1.877275670E-14,   4.626360400E+04,   6.171193240E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">144.000</LJ_welldepth>
+        <LJ_diameter units="A">3.800</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH2(S)    -->
+    <species name="CH2(S)">
+      <atomArray>H:2 C:1 </atomArray>
+      <note>L S/93</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.198604110E+00,  -2.366614190E-03,   8.232962200E-06,  -6.688159810E-09, 
+             1.943147370E-12,   5.049681630E+04,  -7.691189670E-01</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.292038420E+00,   4.655886370E-03,  -2.011919470E-06,   4.179060000E-10, 
+             -3.397163650E-14,   5.092599970E+04,   8.626501690E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">144.000</LJ_welldepth>
+        <LJ_diameter units="A">3.800</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH3    -->
+    <species name="CH3">
+      <atomArray>H:3 C:1 </atomArray>
+      <note>L11/89</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.673590400E+00,   2.010951750E-03,   5.730218560E-06,  -6.871174250E-09, 
+             2.543857340E-12,   1.644499880E+04,   1.604564330E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.285717720E+00,   7.239900370E-03,  -2.987143480E-06,   5.956846440E-10, 
+             -4.671543940E-14,   1.677558430E+04,   8.480071790E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">144.000</LJ_welldepth>
+        <LJ_diameter units="A">3.800</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH4    -->
+    <species name="CH4">
+      <atomArray>H:4 C:1 </atomArray>
+      <note>L 8/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.149876130E+00,  -1.367097880E-02,   4.918005990E-05,  -4.847430260E-08, 
+             1.666939560E-11,  -1.024664760E+04,  -4.641303760E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             7.485149500E-02,   1.339094670E-02,  -5.732858090E-06,   1.222925350E-09, 
+             -1.018152300E-13,  -9.468344590E+03,   1.843731800E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">141.400</LJ_welldepth>
+        <LJ_diameter units="A">3.750</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">2.600</polarizability>
+        <rotRelax>13.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CO    -->
+    <species name="CO">
+      <atomArray>C:1 O:1 </atomArray>
+      <note>TPIS79</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.579533470E+00,  -6.103536800E-04,   1.016814330E-06,   9.070058840E-10, 
+             -9.044244990E-13,  -1.434408600E+04,   3.508409280E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.715185610E+00,   2.062527430E-03,  -9.988257710E-07,   2.300530080E-10, 
+             -2.036477160E-14,  -1.415187240E+04,   7.818687720E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">98.100</LJ_welldepth>
+        <LJ_diameter units="A">3.650</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">1.950</polarizability>
+        <rotRelax>1.800</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CO2    -->
+    <species name="CO2">
+      <atomArray>C:1 O:2 </atomArray>
+      <note>L 7/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.356773520E+00,   8.984596770E-03,  -7.123562690E-06,   2.459190220E-09, 
+             -1.436995480E-13,  -4.837196970E+04,   9.901052220E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.857460290E+00,   4.414370260E-03,  -2.214814040E-06,   5.234901880E-10, 
+             -4.720841640E-14,  -4.875916600E+04,   2.271638060E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">244.000</LJ_welldepth>
+        <LJ_diameter units="A">3.760</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">2.650</polarizability>
+        <rotRelax>2.100</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HCO    -->
+    <species name="HCO">
+      <atomArray>H:1 C:1 O:1 </atomArray>
+      <note>L12/89</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.221185840E+00,  -3.243925320E-03,   1.377994460E-05,  -1.331440930E-08, 
+             4.337688650E-12,   3.839564960E+03,   3.394372430E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.772174380E+00,   4.956955260E-03,  -2.484456130E-06,   5.891617780E-10, 
+             -5.335087110E-14,   4.011918150E+03,   9.798344920E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">498.000</LJ_welldepth>
+        <LJ_diameter units="A">3.590</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH2O    -->
+    <species name="CH2O">
+      <atomArray>H:2 C:1 O:1 </atomArray>
+      <note>L 8/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.793723150E+00,  -9.908333690E-03,   3.732200080E-05,  -3.792852610E-08, 
+             1.317726520E-11,  -1.430895670E+04,   6.028129000E-01</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             1.760690080E+00,   9.200000820E-03,  -4.422588130E-06,   1.006412120E-09, 
+             -8.838556400E-14,  -1.399583230E+04,   1.365632300E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">498.000</LJ_welldepth>
+        <LJ_diameter units="A">3.590</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH2OH    -->
+    <species name="CH2OH">
+      <atomArray>H:3 C:1 O:1 </atomArray>
+      <note>GUNL93</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.863889180E+00,   5.596723040E-03,   5.932717910E-06,  -1.045320120E-08, 
+             4.369672780E-12,  -3.193913670E+03,   5.473022430E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.692665690E+00,   8.645767970E-03,  -3.751011200E-06,   7.872346360E-10, 
+             -6.485542010E-14,  -3.242506270E+03,   5.810432150E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">417.000</LJ_welldepth>
+        <LJ_diameter units="A">3.690</LJ_diameter>
+        <dipoleMoment units="Debye">1.700</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH3O    -->
+    <species name="CH3O">
+      <atomArray>H:3 C:1 O:1 </atomArray>
+      <note>121686</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.106204000E+00,   7.216595000E-03,   5.338472000E-06,  -7.377636000E-09, 
+             2.075610000E-12,   9.786011000E+02,   1.315217700E+01</floatArray>
+        </NASA>
+        <NASA Tmax="3000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.770799000E+00,   7.871497000E-03,  -2.656384000E-06,   3.944431000E-10, 
+             -2.112616000E-14,   1.278325200E+02,   2.929575000E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">417.000</LJ_welldepth>
+        <LJ_diameter units="A">3.690</LJ_diameter>
+        <dipoleMoment units="Debye">1.700</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH3OH    -->
+    <species name="CH3OH">
+      <atomArray>H:4 C:1 O:1 </atomArray>
+      <note>L 8/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.715395820E+00,  -1.523091290E-02,   6.524411550E-05,  -7.108068890E-08, 
+             2.613526980E-11,  -2.564276560E+04,  -1.504098230E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             1.789707910E+00,   1.409382920E-02,  -6.365008350E-06,   1.381710850E-09, 
+             -1.170602200E-13,  -2.537487470E+04,   1.450236230E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">481.800</LJ_welldepth>
+        <LJ_diameter units="A">3.630</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C2H    -->
+    <species name="C2H">
+      <atomArray>H:1 C:2 </atomArray>
+      <note>L 1/91</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.889657330E+00,   1.340996110E-02,  -2.847695010E-05,   2.947910450E-08, 
+             -1.093315110E-11,   6.683939320E+04,   6.222964380E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.167806520E+00,   4.752219020E-03,  -1.837870770E-06,   3.041902520E-10, 
+             -1.772327700E-14,   6.712106500E+04,   6.635894750E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">209.000</LJ_welldepth>
+        <LJ_diameter units="A">4.100</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.500</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C2H2    -->
+    <species name="C2H2">
+      <atomArray>H:2 C:2 </atomArray>
+      <note>L 1/91</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             8.086810940E-01,   2.336156290E-02,  -3.551718150E-05,   2.801524370E-08, 
+             -8.500729740E-12,   2.642898070E+04,   1.393970510E+01</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.147569640E+00,   5.961666640E-03,  -2.372948520E-06,   4.674121710E-10, 
+             -3.612352130E-14,   2.593599920E+04,  -1.230281210E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">209.000</LJ_welldepth>
+        <LJ_diameter units="A">4.100</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.500</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C2H3    -->
+    <species name="C2H3">
+      <atomArray>H:3 C:2 </atomArray>
+      <note>L 2/92</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.212466450E+00,   1.514791620E-03,   2.592094120E-05,  -3.576578470E-08, 
+             1.471508730E-11,   3.485984680E+04,   8.510540250E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.016724000E+00,   1.033022920E-02,  -4.680823490E-06,   1.017632880E-09, 
+             -8.626070410E-14,   3.461287390E+04,   7.787323780E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">209.000</LJ_welldepth>
+        <LJ_diameter units="A">4.100</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C2H4    -->
+    <species name="C2H4">
+      <atomArray>H:4 C:2 </atomArray>
+      <note>L 1/91</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.959201480E+00,  -7.570522470E-03,   5.709902920E-05,  -6.915887530E-08, 
+             2.698843730E-11,   5.089775930E+03,   4.097330960E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.036111160E+00,   1.464541510E-02,  -6.710779150E-06,   1.472229230E-09, 
+             -1.257060610E-13,   4.939886140E+03,   1.030536930E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">280.800</LJ_welldepth>
+        <LJ_diameter units="A">3.970</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.500</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C2H5    -->
+    <species name="C2H5">
+      <atomArray>H:5 C:2 </atomArray>
+      <note>L12/92</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.306465680E+00,  -4.186588920E-03,   4.971428070E-05,  -5.991266060E-08, 
+             2.305090040E-11,   1.284162650E+04,   4.707209240E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             1.954656420E+00,   1.739727220E-02,  -7.982066680E-06,   1.752176890E-09, 
+             -1.496415760E-13,   1.285752000E+04,   1.346243430E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">252.300</LJ_welldepth>
+        <LJ_diameter units="A">4.300</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.500</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C2H6    -->
+    <species name="C2H6">
+      <atomArray>H:6 C:2 </atomArray>
+      <note>L 8/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.291424920E+00,  -5.501542700E-03,   5.994382880E-05,  -7.084662850E-08, 
+             2.686857710E-11,  -1.152220550E+04,   2.666823160E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             1.071881500E+00,   2.168526770E-02,  -1.002560670E-05,   2.214120010E-09, 
+             -1.900028900E-13,  -1.142639320E+04,   1.511561070E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">252.300</LJ_welldepth>
+        <LJ_diameter units="A">4.300</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.500</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HCCO    -->
+    <species name="HCCO">
+      <atomArray>H:1 C:2 O:1 </atomArray>
+      <note>SRIC91</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.251721400E+00,   1.765502100E-02,  -2.372910100E-05,   1.727575900E-08, 
+             -5.066481100E-12,   2.005944900E+04,   1.249041700E+01</floatArray>
+        </NASA>
+        <NASA Tmax="4000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.628205800E+00,   4.085340100E-03,  -1.593454700E-06,   2.862605200E-10, 
+             -1.940783200E-14,   1.932721500E+04,  -3.930259500E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">150.000</LJ_welldepth>
+        <LJ_diameter units="A">2.500</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH2CO    -->
+    <species name="CH2CO">
+      <atomArray>H:2 C:2 O:1 </atomArray>
+      <note>L 5/90</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.135836300E+00,   1.811887210E-02,  -1.739474740E-05,   9.343975680E-09, 
+             -2.014576150E-12,  -7.042918040E+03,   1.221564800E+01</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.511297320E+00,   9.003597450E-03,  -4.169396350E-06,   9.233458820E-10, 
+             -7.948382010E-14,  -7.551053110E+03,   6.322472050E-01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">436.000</LJ_welldepth>
+        <LJ_diameter units="A">3.970</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HCCOH    -->
+    <species name="HCCOH">
+      <atomArray>H:2 C:2 O:1 </atomArray>
+      <note>SRI91</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             1.242373300E+00,   3.107220100E-02,  -5.086686400E-05,   4.313713100E-08, 
+             -1.401459400E-11,   8.031614300E+03,   1.387431900E+01</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.923829100E+00,   6.792360000E-03,  -2.565856400E-06,   4.498784100E-10, 
+             -2.994010100E-14,   7.264626000E+03,  -7.601774200E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">436.000</LJ_welldepth>
+        <LJ_diameter units="A">3.970</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species N    -->
+    <species name="N">
+      <atomArray>N:1 </atomArray>
+      <note>L 6/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.500000000E+00,   0.000000000E+00,   0.000000000E+00,   0.000000000E+00, 
+             0.000000000E+00,   5.610463700E+04,   4.193908700E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.415942900E+00,   1.748906500E-04,  -1.190236900E-07,   3.022624500E-11, 
+             -2.036098200E-15,   5.613377300E+04,   4.649609600E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">atom</string>
+        <LJ_welldepth units="K">71.400</LJ_welldepth>
+        <LJ_diameter units="A">3.300</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species NH    -->
+    <species name="NH">
+      <atomArray>H:1 N:1 </atomArray>
+      <note>And94</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.492908500E+00,   3.117919800E-04,  -1.489048400E-06,   2.481644200E-09, 
+             -1.035696700E-12,   4.188062900E+04,   1.848327800E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.783692800E+00,   1.329843000E-03,  -4.247804700E-07,   7.834850100E-11, 
+             -5.504447000E-15,   4.212084800E+04,   5.740779900E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">80.000</LJ_welldepth>
+        <LJ_diameter units="A">2.650</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>4.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species NH2    -->
+    <species name="NH2">
+      <atomArray>H:2 N:1 </atomArray>
+      <note>And89</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.204002900E+00,  -2.106138500E-03,   7.106834800E-06,  -5.611519700E-09, 
+             1.644071700E-12,   2.188591000E+04,  -1.418424800E-01</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.834742100E+00,   3.207308200E-03,  -9.339080400E-07,   1.370295300E-10, 
+             -7.920614400E-15,   2.217195700E+04,   6.520416300E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">80.000</LJ_welldepth>
+        <LJ_diameter units="A">2.650</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">2.260</polarizability>
+        <rotRelax>4.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species NH3    -->
+    <species name="NH3">
+      <atomArray>H:3 N:1 </atomArray>
+      <note>J 6/77</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.286027400E+00,  -4.660523000E-03,   2.171851300E-05,  -2.280888700E-08, 
+             8.263804600E-12,  -6.741728500E+03,  -6.253727700E-01</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.634452100E+00,   5.666256000E-03,  -1.727867600E-06,   2.386716100E-10, 
+             -1.257878600E-14,  -6.544695800E+03,   6.566292800E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">481.000</LJ_welldepth>
+        <LJ_diameter units="A">2.920</LJ_diameter>
+        <dipoleMoment units="Debye">1.470</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>10.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species NNH    -->
+    <species name="NNH">
+      <atomArray>H:1 N:2 </atomArray>
+      <note>T07/93</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.344692700E+00,  -4.849707200E-03,   2.005945900E-05,  -2.172646400E-08, 
+             7.946953900E-12,   2.879197300E+04,   2.977941000E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.766754400E+00,   2.891508200E-03,  -1.041662000E-06,   1.684259400E-10, 
+             -1.009189600E-14,   2.865069700E+04,   4.470506700E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">71.400</LJ_welldepth>
+        <LJ_diameter units="A">3.800</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species NO    -->
+    <species name="NO">
+      <atomArray>O:1 N:1 </atomArray>
+      <note>RUS 78</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.218476300E+00,  -4.638976000E-03,   1.104102200E-05,  -9.336135400E-09, 
+             2.803577000E-12,   9.844623000E+03,   2.280846400E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.260605600E+00,   1.191104300E-03,  -4.291704800E-07,   6.945766900E-11, 
+             -4.033609900E-15,   9.920974600E+03,   6.369302700E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">97.530</LJ_welldepth>
+        <LJ_diameter units="A">3.620</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">1.760</polarizability>
+        <rotRelax>4.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species NO2    -->
+    <species name="NO2">
+      <atomArray>O:2 N:1 </atomArray>
+      <note>L 7/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.944031200E+00,  -1.585429000E-03,   1.665781200E-05,  -2.047542600E-08, 
+             7.835056400E-12,   2.896617900E+03,   6.311991700E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.884754200E+00,   2.172395600E-03,  -8.280690600E-07,   1.574751000E-10, 
+             -1.051089500E-14,   2.316498300E+03,  -1.174169500E-01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">200.000</LJ_welldepth>
+        <LJ_diameter units="A">3.500</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species N2O    -->
+    <species name="N2O">
+      <atomArray>O:1 N:2 </atomArray>
+      <note>L 7/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.257150200E+00,   1.130472800E-02,  -1.367131900E-05,   9.681980600E-09, 
+             -2.930718200E-12,   8.741774400E+03,   1.075799200E+01</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.823072900E+00,   2.627025100E-03,  -9.585087400E-07,   1.600071200E-10, 
+             -9.775230300E-15,   8.073404800E+03,  -2.201720700E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">232.400</LJ_welldepth>
+        <LJ_diameter units="A">3.830</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HNO    -->
+    <species name="HNO">
+      <atomArray>H:1 O:1 N:1 </atomArray>
+      <note>And93</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.533491600E+00,  -5.669617100E-03,   1.847320700E-05,  -1.713709400E-08, 
+             5.545457300E-12,   1.154829700E+04,   1.749841700E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.979250900E+00,   3.494405900E-03,  -7.854977800E-07,   5.747959400E-11, 
+             -1.933591600E-16,   1.175058200E+04,   8.606372800E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">116.700</LJ_welldepth>
+        <LJ_diameter units="A">3.490</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CN    -->
+    <species name="CN">
+      <atomArray>C:1 N:1 </atomArray>
+      <note>HBH92</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.612935100E+00,  -9.555132700E-04,   2.144297700E-06,  -3.151632300E-10, 
+             -4.643035600E-13,   5.170834000E+04,   3.980499500E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.745980500E+00,   4.345077500E-05,   2.970598400E-07,  -6.865180600E-11, 
+             4.413417300E-15,   5.153618800E+04,   2.786760100E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">75.000</LJ_welldepth>
+        <LJ_diameter units="A">3.860</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HCN    -->
+    <species name="HCN">
+      <atomArray>H:1 C:1 N:1 </atomArray>
+      <note>GRI/98</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.258988600E+00,   1.005117000E-02,  -1.335176300E-05,   1.009234900E-08, 
+             -3.008902800E-12,   1.471263300E+04,   8.916441900E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.802239200E+00,   3.146422800E-03,  -1.063218500E-06,   1.661975700E-10, 
+             -9.799757000E-15,   1.440729200E+04,   1.575460100E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">569.000</LJ_welldepth>
+        <LJ_diameter units="A">3.630</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species H2CN    -->
+    <species name="H2CN">
+      <atomArray>H:2 C:1 N:1 </atomArray>
+      <note>41687</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.851661000E+00,   5.695233100E-03,   1.071140000E-06,  -1.622612000E-09, 
+             -2.351108100E-13,   2.863782000E+04,   8.992751100E+00</floatArray>
+        </NASA>
+        <NASA Tmax="4000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.209703000E+00,   2.969291100E-03,  -2.855589100E-07,  -1.635550000E-10, 
+             3.043258900E-14,   2.767710900E+04,  -4.444478000E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">569.000</LJ_welldepth>
+        <LJ_diameter units="A">3.630</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HCNN    -->
+    <species name="HCNN">
+      <atomArray>H:1 C:1 N:2 </atomArray>
+      <note>SRI/94</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.524319400E+00,   1.596061900E-02,  -1.881635400E-05,   1.212554000E-08, 
+             -3.235737800E-12,   5.426198400E+04,   1.167587000E+01</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.894636200E+00,   3.989595900E-03,  -1.598238000E-06,   2.924939500E-10, 
+             -2.009468600E-14,   5.345294100E+04,  -5.103050200E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">150.000</LJ_welldepth>
+        <LJ_diameter units="A">2.500</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HCNO    -->
+    <species name="HCNO">
+      <atomArray>H:1 C:1 O:1 N:1 </atomArray>
+      <note>BDEA94</note>
+      <thermo>
+        <NASA Tmax="1382.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.647279890E+00,   1.275053420E-02,  -1.047942360E-05,   4.414328360E-09, 
+             -7.575214660E-13,   1.929902520E+04,   1.073329720E+01</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1382.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             6.598604560E+00,   3.027786260E-03,  -1.077043460E-06,   1.716665280E-10, 
+             -1.014393910E-14,   1.796613390E+04,  -1.033065990E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">232.400</LJ_welldepth>
+        <LJ_diameter units="A">3.830</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HOCN    -->
+    <species name="HOCN">
+      <atomArray>H:1 C:1 O:1 N:1 </atomArray>
+      <note>BDEA94</note>
+      <thermo>
+        <NASA Tmax="1368.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.786049520E+00,   6.886679220E-03,  -3.214878640E-06,   5.171957670E-10, 
+             1.193607880E-14,  -2.826984000E+03,   5.632921620E+00</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1368.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.897848850E+00,   3.167893930E-03,  -1.118010640E-06,   1.772431440E-10, 
+             -1.043391770E-14,  -3.706533310E+03,  -6.181678250E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">232.400</LJ_welldepth>
+        <LJ_diameter units="A">3.830</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species HNCO    -->
+    <species name="HNCO">
+      <atomArray>H:1 C:1 O:1 N:1 </atomArray>
+      <note>BDEA94</note>
+      <thermo>
+        <NASA Tmax="1478.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.630963170E+00,   7.302823570E-03,  -2.280500030E-06,  -6.612712980E-10, 
+             3.622357520E-13,  -1.558736360E+04,   6.194577270E+00</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1478.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             6.223951340E+00,   3.178640040E-03,  -1.093787550E-06,   1.707351630E-10, 
+             -9.950219550E-15,  -1.665993440E+04,  -8.382247410E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">232.400</LJ_welldepth>
+        <LJ_diameter units="A">3.830</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species NCO    -->
+    <species name="NCO">
+      <atomArray>C:1 O:1 N:1 </atomArray>
+      <note>EA 93</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.826930800E+00,   8.805168800E-03,  -8.386613400E-06,   4.801696400E-09, 
+             -1.331359500E-12,   1.468247700E+04,   9.550464600E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.152184500E+00,   2.305176100E-03,  -8.803315300E-07,   1.478909800E-10, 
+             -9.097799600E-15,   1.400412300E+04,  -2.544266000E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">232.400</LJ_welldepth>
+        <LJ_diameter units="A">3.830</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species N2    -->
+    <species name="N2">
+      <atomArray>N:2 </atomArray>
+      <note>121286</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.298677000E+00,   1.408240400E-03,  -3.963222000E-06,   5.641515000E-09, 
+             -2.444854000E-12,  -1.020899900E+03,   3.950372000E+00</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.926640000E+00,   1.487976800E-03,  -5.684760000E-07,   1.009703800E-10, 
+             -6.753351000E-15,  -9.227977000E+02,   5.980528000E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">linear</string>
+        <LJ_welldepth units="K">97.530</LJ_welldepth>
+        <LJ_diameter units="A">3.620</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">1.760</polarizability>
+        <rotRelax>4.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species AR    -->
+    <species name="AR">
+      <atomArray>Ar:1 </atomArray>
+      <note>120186</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.500000000E+00,   0.000000000E+00,   0.000000000E+00,   0.000000000E+00, 
+             0.000000000E+00,  -7.453750000E+02,   4.366000000E+00</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             2.500000000E+00,   0.000000000E+00,   0.000000000E+00,   0.000000000E+00, 
+             0.000000000E+00,  -7.453750000E+02,   4.366000000E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">atom</string>
+        <LJ_welldepth units="K">136.500</LJ_welldepth>
+        <LJ_diameter units="A">3.330</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>0.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C3H7    -->
+    <species name="C3H7">
+      <atomArray>H:7 C:3 </atomArray>
+      <note>L 9/84</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             1.051551800E+00,   2.599198000E-02,   2.380054000E-06,  -1.960956900E-08, 
+             9.373247000E-12,   1.063186300E+04,   2.112255900E+01</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             7.702698700E+00,   1.604420300E-02,  -5.283322000E-06,   7.629859000E-10, 
+             -3.939228400E-14,   8.298433600E+03,  -1.548018000E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">266.800</LJ_welldepth>
+        <LJ_diameter units="A">4.980</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species C3H8    -->
+    <species name="C3H8">
+      <atomArray>H:8 C:3 </atomArray>
+      <note>L 4/85</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             9.335538100E-01,   2.642457900E-02,   6.105972700E-06,  -2.197749900E-08, 
+             9.514925300E-12,  -1.395852000E+04,   1.920169100E+01</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             7.534136800E+00,   1.887223900E-02,  -6.271849100E-06,   9.147564900E-10, 
+             -4.783806900E-14,  -1.646751600E+04,  -1.789234900E+01</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">266.800</LJ_welldepth>
+        <LJ_diameter units="A">4.980</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>1.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH2CHO    -->
+    <species name="CH2CHO">
+      <atomArray>H:3 C:2 O:1 </atomArray>
+      <note>SAND86</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="300.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             3.409062000E+00,   1.073857400E-02,   1.891492000E-06,  -7.158583000E-09, 
+             2.867385000E-12,   1.521476600E+03,   9.558290000E+00</floatArray>
+        </NASA>
+        <NASA Tmax="5000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.975670000E+00,   8.130591000E-03,  -2.743624000E-06,   4.070304000E-10, 
+             -2.176017000E-14,   4.903218000E+02,  -5.045251000E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">436.000</LJ_welldepth>
+        <LJ_diameter units="A">3.970</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.000</rotRelax>
+      </transport>
+    </species>
+
+    <!-- species CH3CHO    -->
+    <species name="CH3CHO">
+      <atomArray>H:4 C:2 O:1 </atomArray>
+      <note>L 8/88</note>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             4.729459500E+00,  -3.193285800E-03,   4.753492100E-05,  -5.745861100E-08, 
+             2.193111200E-11,  -2.157287800E+04,   4.103015900E+00</floatArray>
+        </NASA>
+        <NASA Tmax="6000.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.404110800E+00,   1.172305900E-02,  -4.226313700E-06,   6.837245100E-10, 
+             -4.098486300E-14,  -2.259312200E+04,  -3.480791700E+00</floatArray>
+        </NASA>
+      </thermo>
+      <transport model="gas_transport">
+        <string title="geometry">nonlinear</string>
+        <LJ_welldepth units="K">436.000</LJ_welldepth>
+        <LJ_diameter units="A">3.970</LJ_diameter>
+        <dipoleMoment units="Debye">0.000</dipoleMoment>
+        <polarizability units="A3">0.000</polarizability>
+        <rotRelax>2.000</rotRelax>
+      </transport>
+    </species>
+  </speciesData>
+  <reactionData id="reaction_data">
+
+    <!-- reaction 0001    -->
+    <reaction reversible="yes" type="threeBody" id="0001">
+      <equation>2 O + M [=] O2 + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.200000E+11</A>
+           <b>-1</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.83  C2H6:3  CH4:2  CO:1.75  CO2:3.6  H2:2.4  H2O:15.4 </efficiencies>
+      </rateCoeff>
+      <reactants>O:2.0</reactants>
+      <products>O2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0002    -->
+    <reaction reversible="yes" type="threeBody" id="0002">
+      <equation>O + H + M [=] OH + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+11</A>
+           <b>-1</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+      </rateCoeff>
+      <reactants>H:1 O:1.0</reactants>
+      <products>OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0003    -->
+    <reaction reversible="yes" id="0003">
+      <equation>O + H2 [=] H + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.870000E+01</A>
+           <b>2.7</b>
+           <E units="cal/mol">6260.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2:1 O:1.0</reactants>
+      <products>H:1.0 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0004    -->
+    <reaction reversible="yes" id="0004">
+      <equation>O + HO2 [=] OH + O2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HO2:1 O:1.0</reactants>
+      <products>O2:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0005    -->
+    <reaction reversible="yes" id="0005">
+      <equation>O + H2O2 [=] OH + HO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.630000E+03</A>
+           <b>2</b>
+           <E units="cal/mol">4000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2O2:1 O:1.0</reactants>
+      <products>HO2:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0006    -->
+    <reaction reversible="yes" id="0006">
+      <equation>O + CH [=] H + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.700000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1 O:1.0</reactants>
+      <products>H:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0007    -->
+    <reaction reversible="yes" id="0007">
+      <equation>O + CH2 [=] H + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>8.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1 O:1.0</reactants>
+      <products>H:1.0 HCO:1</products>
+    </reaction>
+
+    <!-- reaction 0008    -->
+    <reaction reversible="yes" id="0008">
+      <equation>O + CH2(S) [=] H2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1 O:1.0</reactants>
+      <products>H2:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0009    -->
+    <reaction reversible="yes" id="0009">
+      <equation>O + CH2(S) [=] H + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1 O:1.0</reactants>
+      <products>H:1.0 HCO:1</products>
+    </reaction>
+
+    <!-- reaction 0010    -->
+    <reaction reversible="yes" id="0010">
+      <equation>O + CH3 [=] H + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.060000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 O:1.0</reactants>
+      <products>CH2O:1 H:1.0</products>
+    </reaction>
+
+    <!-- reaction 0011    -->
+    <reaction reversible="yes" id="0011">
+      <equation>O + CH4 [=] OH + CH3</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.020000E+06</A>
+           <b>1.5</b>
+           <E units="cal/mol">8600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH4:1 O:1.0</reactants>
+      <products>CH3:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0012    -->
+    <reaction reversible="yes" type="falloff" id="0012">
+      <equation>O + CO (+ M) [=] CO2 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.800000E+07</A>
+           <b>0</b>
+           <E units="cal/mol">2385.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>6.020000E+08</A>
+           <b>0</b>
+           <E units="cal/mol">3000.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.5  C2H6:3  CH4:2  CO:1.5  CO2:3.5  H2:2  H2O:6  O2:6 </efficiencies>
+        <falloff type="Lindemann"/>
+      </rateCoeff>
+      <reactants>CO:1 O:1.0</reactants>
+      <products>CO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0013    -->
+    <reaction reversible="yes" id="0013">
+      <equation>O + HCO [=] OH + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCO:1 O:1.0</reactants>
+      <products>CO:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0014    -->
+    <reaction reversible="yes" id="0014">
+      <equation>O + HCO [=] H + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCO:1 O:1.0</reactants>
+      <products>H:1.0 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0015    -->
+    <reaction reversible="yes" id="0015">
+      <equation>O + CH2O [=] OH + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.900000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">3540.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2O:1 O:1.0</reactants>
+      <products>HCO:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0016    -->
+    <reaction reversible="yes" id="0016">
+      <equation>O + CH2OH [=] OH + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2OH:1 O:1.0</reactants>
+      <products>CH2O:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0017    -->
+    <reaction reversible="yes" id="0017">
+      <equation>O + CH3O [=] OH + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3O:1 O:1.0</reactants>
+      <products>CH2O:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0018    -->
+    <reaction reversible="yes" id="0018">
+      <equation>O + CH3OH [=] OH + CH2OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.880000E+02</A>
+           <b>2.5</b>
+           <E units="cal/mol">3100.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3OH:1 O:1.0</reactants>
+      <products>CH2OH:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0019    -->
+    <reaction reversible="yes" id="0019">
+      <equation>O + CH3OH [=] OH + CH3O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.300000E+02</A>
+           <b>2.5</b>
+           <E units="cal/mol">5000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3OH:1 O:1.0</reactants>
+      <products>CH3O:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0020    -->
+    <reaction reversible="yes" id="0020">
+      <equation>O + C2H [=] CH + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H:1 O:1.0</reactants>
+      <products>CH:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0021    -->
+    <reaction reversible="yes" id="0021">
+      <equation>O + C2H2 [=] H + HCCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.350000E+04</A>
+           <b>2</b>
+           <E units="cal/mol">1900.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H2:1 O:1.0</reactants>
+      <products>H:1.0 HCCO:1</products>
+    </reaction>
+
+    <!-- reaction 0022    -->
+    <reaction reversible="yes" id="0022">
+      <equation>O + C2H2 [=] OH + C2H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.600000E+16</A>
+           <b>-1.41</b>
+           <E units="cal/mol">28950.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H2:1 O:1.0</reactants>
+      <products>C2H:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0023    -->
+    <reaction reversible="yes" id="0023">
+      <equation>O + C2H2 [=] CO + CH2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.940000E+03</A>
+           <b>2</b>
+           <E units="cal/mol">1900.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H2:1 O:1.0</reactants>
+      <products>CH2:1 CO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0024    -->
+    <reaction reversible="yes" id="0024">
+      <equation>O + C2H3 [=] H + CH2CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H3:1 O:1.0</reactants>
+      <products>H:1.0 CH2CO:1</products>
+    </reaction>
+
+    <!-- reaction 0025    -->
+    <reaction reversible="yes" id="0025">
+      <equation>O + C2H4 [=] CH3 + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.250000E+04</A>
+           <b>1.83</b>
+           <E units="cal/mol">220.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H4:1 O:1.0</reactants>
+      <products>CH3:1.0 HCO:1</products>
+    </reaction>
+
+    <!-- reaction 0026    -->
+    <reaction reversible="yes" id="0026">
+      <equation>O + C2H5 [=] CH3 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.240000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H5:1 O:1.0</reactants>
+      <products>CH2O:1 CH3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0027    -->
+    <reaction reversible="yes" id="0027">
+      <equation>O + C2H6 [=] OH + C2H5</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>8.980000E+04</A>
+           <b>1.92</b>
+           <E units="cal/mol">5690.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H6:1 O:1.0</reactants>
+      <products>C2H5:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0028    -->
+    <reaction reversible="yes" id="0028">
+      <equation>O + HCCO [=] H + 2 CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCCO:1 O:1.0</reactants>
+      <products>H:1.0 CO:2.0</products>
+    </reaction>
+
+    <!-- reaction 0029    -->
+    <reaction reversible="yes" id="0029">
+      <equation>O + CH2CO [=] OH + HCCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">8000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2CO:1 O:1.0</reactants>
+      <products>HCCO:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0030    -->
+    <reaction reversible="yes" id="0030">
+      <equation>O + CH2CO [=] CH2 + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.750000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">1350.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2CO:1 O:1.0</reactants>
+      <products>CH2:1.0 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0031    -->
+    <reaction reversible="yes" id="0031">
+      <equation>O2 + CO [=] O + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.500000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">47800.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CO:1 O2:1.0</reactants>
+      <products>CO2:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0032    -->
+    <reaction reversible="yes" id="0032">
+      <equation>O2 + CH2O [=] HO2 + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">40000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2O:1 O2:1.0</reactants>
+      <products>HO2:1.0 HCO:1</products>
+    </reaction>
+
+    <!-- reaction 0033    -->
+    <reaction reversible="yes" type="threeBody" id="0033">
+      <equation>H + O2 + M [=] HO2 + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.800000E+12</A>
+           <b>-0.86</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0  C2H6:1.5  CO:0.75  CO2:1.5  H2O:0  N2:0  O2:0 </efficiencies>
+      </rateCoeff>
+      <reactants>H:1.0 O2:1</reactants>
+      <products>HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0034    -->
+    <reaction reversible="yes" id="0034">
+      <equation>H + 2 O2 [=] HO2 + O2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.080000E+13</A>
+           <b>-1.24</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 O2:2.0</reactants>
+      <products>HO2:1.0 O2:1</products>
+    </reaction>
+
+    <!-- reaction 0035    -->
+    <reaction reversible="yes" id="0035">
+      <equation>H + O2 + H2O [=] HO2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.126000E+13</A>
+           <b>-0.76</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 H2O:1 O2:1</reactants>
+      <products>H2O:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0036    -->
+    <reaction reversible="yes" id="0036">
+      <equation>H + O2 + N2 [=] HO2 + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.600000E+13</A>
+           <b>-1.24</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 N2:1 O2:1</reactants>
+      <products>N2:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0037    -->
+    <reaction reversible="yes" id="0037">
+      <equation>H + O2 + AR [=] HO2 + AR</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.000000E+11</A>
+           <b>-0.8</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 AR:1 O2:1</reactants>
+      <products>AR:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0038    -->
+    <reaction reversible="yes" id="0038">
+      <equation>H + O2 [=] O + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.650000E+13</A>
+           <b>-0.6707</b>
+           <E units="cal/mol">17041.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 O2:1</reactants>
+      <products>O:1.0 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0039    -->
+    <reaction reversible="yes" type="threeBody" id="0039">
+      <equation>2 H + M [=] H2 + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+12</A>
+           <b>-1</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.63  C2H6:3  CH4:2  CO2:0  H2:0  H2O:0 </efficiencies>
+      </rateCoeff>
+      <reactants>H:2.0</reactants>
+      <products>H2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0040    -->
+    <reaction reversible="yes" id="0040">
+      <equation>2 H + H2 [=] 2 H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.000000E+10</A>
+           <b>-0.6</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2:1 H:2.0</reactants>
+      <products>H2:2.0</products>
+    </reaction>
+
+    <!-- reaction 0041    -->
+    <reaction reversible="yes" id="0041">
+      <equation>2 H + H2O [=] H2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.000000E+13</A>
+           <b>-1.25</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:2.0 H2O:1</reactants>
+      <products>H2:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0042    -->
+    <reaction reversible="yes" id="0042">
+      <equation>2 H + CO2 [=] H2 + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.500000E+14</A>
+           <b>-2</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:2.0 CO2:1</reactants>
+      <products>H2:1.0 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0043    -->
+    <reaction reversible="yes" type="threeBody" id="0043">
+      <equation>H + OH + M [=] H2O + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.200000E+16</A>
+           <b>-2</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.38  C2H6:3  CH4:2  H2:0.73  H2O:3.65 </efficiencies>
+      </rateCoeff>
+      <reactants>H:1.0 OH:1</reactants>
+      <products>H2O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0044    -->
+    <reaction reversible="yes" id="0044">
+      <equation>H + HO2 [=] O + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.970000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">671.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 HO2:1</reactants>
+      <products>H2O:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0045    -->
+    <reaction reversible="yes" id="0045">
+      <equation>H + HO2 [=] O2 + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.480000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">1068.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 HO2:1</reactants>
+      <products>H2:1 O2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0046    -->
+    <reaction reversible="yes" id="0046">
+      <equation>H + HO2 [=] 2 OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>8.400000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">635.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 HO2:1</reactants>
+      <products>OH:2.0</products>
+    </reaction>
+
+    <!-- reaction 0047    -->
+    <reaction reversible="yes" id="0047">
+      <equation>H + H2O2 [=] HO2 + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.210000E+04</A>
+           <b>2</b>
+           <E units="cal/mol">5200.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 H2O2:1</reactants>
+      <products>H2:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0048    -->
+    <reaction reversible="yes" id="0048">
+      <equation>H + H2O2 [=] OH + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">3600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 H2O2:1</reactants>
+      <products>H2O:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0049    -->
+    <reaction reversible="yes" id="0049">
+      <equation>H + CH [=] C + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.650000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH:1</reactants>
+      <products>H2:1 C:1.0</products>
+    </reaction>
+
+    <!-- reaction 0050    -->
+    <reaction reversible="yes" type="falloff" id="0050">
+      <equation>H + CH2 (+ M) [=] CH3 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.000000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.040000E+20</A>
+           <b>-2.76</b>
+           <E units="cal/mol">1600.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.562 91 5836 8552 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 CH2:1</reactants>
+      <products>CH3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0051    -->
+    <reaction reversible="yes" id="0051">
+      <equation>H + CH2(S) [=] CH + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH2(S):1</reactants>
+      <products>H2:1 CH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0052    -->
+    <reaction reversible="yes" type="falloff" id="0052">
+      <equation>H + CH3 (+ M) [=] CH4 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.390000E+13</A>
+           <b>-0.534</b>
+           <E units="cal/mol">536.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>2.620000E+27</A>
+           <b>-4.76</b>
+           <E units="cal/mol">2440.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:3  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.783 74 2941 6964 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 CH3:1</reactants>
+      <products>CH4:1.0</products>
+    </reaction>
+
+    <!-- reaction 0053    -->
+    <reaction reversible="yes" id="0053">
+      <equation>H + CH4 [=] CH3 + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.600000E+05</A>
+           <b>1.62</b>
+           <E units="cal/mol">10840.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH4:1</reactants>
+      <products>H2:1 CH3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0054    -->
+    <reaction reversible="yes" type="falloff" id="0054">
+      <equation>H + HCO (+ M) [=] CH2O (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.090000E+09</A>
+           <b>0.48</b>
+           <E units="cal/mol">-260.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>2.470000E+18</A>
+           <b>-2.57</b>
+           <E units="cal/mol">425.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.7824 271 2755 6570 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 HCO:1</reactants>
+      <products>CH2O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0055    -->
+    <reaction reversible="yes" id="0055">
+      <equation>H + HCO [=] H2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.340000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 HCO:1</reactants>
+      <products>H2:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0056    -->
+    <reaction reversible="yes" type="falloff" id="0056">
+      <equation>H + CH2O (+ M) [=] CH2OH (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.400000E+08</A>
+           <b>0.454</b>
+           <E units="cal/mol">3600.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.270000E+26</A>
+           <b>-4.82</b>
+           <E units="cal/mol">6530.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.7187 103 1291 4160 </falloff>
+      </rateCoeff>
+      <reactants>CH2O:1 H:1.0</reactants>
+      <products>CH2OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0057    -->
+    <reaction reversible="yes" type="falloff" id="0057">
+      <equation>H + CH2O (+ M) [=] CH3O (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.400000E+08</A>
+           <b>0.454</b>
+           <E units="cal/mol">2600.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>2.200000E+24</A>
+           <b>-4.8</b>
+           <E units="cal/mol">5560.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.758 94 1555 4200 </falloff>
+      </rateCoeff>
+      <reactants>CH2O:1 H:1.0</reactants>
+      <products>CH3O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0058    -->
+    <reaction reversible="yes" id="0058">
+      <equation>H + CH2O [=] HCO + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.740000E+04</A>
+           <b>1.9</b>
+           <E units="cal/mol">2742.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2O:1 H:1.0</reactants>
+      <products>H2:1 HCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0059    -->
+    <reaction reversible="yes" type="falloff" id="0059">
+      <equation>H + CH2OH (+ M) [=] CH3OH (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.055000E+09</A>
+           <b>0.5</b>
+           <E units="cal/mol">86.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>4.360000E+25</A>
+           <b>-4.65</b>
+           <E units="cal/mol">5080.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.6 100 90000 10000 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 CH2OH:1</reactants>
+      <products>CH3OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0060    -->
+    <reaction reversible="yes" id="0060">
+      <equation>H + CH2OH [=] H2 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH2OH:1</reactants>
+      <products>H2:1.0 CH2O:1</products>
+    </reaction>
+
+    <!-- reaction 0061    -->
+    <reaction reversible="yes" id="0061">
+      <equation>H + CH2OH [=] OH + CH3</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.650000E+08</A>
+           <b>0.65</b>
+           <E units="cal/mol">-284.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH2OH:1</reactants>
+      <products>CH3:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0062    -->
+    <reaction reversible="yes" id="0062">
+      <equation>H + CH2OH [=] CH2(S) + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.280000E+10</A>
+           <b>-0.09</b>
+           <E units="cal/mol">610.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH2OH:1</reactants>
+      <products>CH2(S):1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0063    -->
+    <reaction reversible="yes" type="falloff" id="0063">
+      <equation>H + CH3O (+ M) [=] CH3OH (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.430000E+09</A>
+           <b>0.515</b>
+           <E units="cal/mol">50.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>4.660000E+35</A>
+           <b>-7.44</b>
+           <E units="cal/mol">14080.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.7 100 90000 10000 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 CH3O:1</reactants>
+      <products>CH3OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0064    -->
+    <reaction reversible="yes" id="0064">
+      <equation>H + CH3O [=] H + CH2OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.150000E+04</A>
+           <b>1.63</b>
+           <E units="cal/mol">1924.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH3O:1</reactants>
+      <products>H:1.0 CH2OH:1</products>
+    </reaction>
+
+    <!-- reaction 0065    -->
+    <reaction reversible="yes" id="0065">
+      <equation>H + CH3O [=] H2 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH3O:1</reactants>
+      <products>H2:1.0 CH2O:1</products>
+    </reaction>
+
+    <!-- reaction 0066    -->
+    <reaction reversible="yes" id="0066">
+      <equation>H + CH3O [=] OH + CH3</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+09</A>
+           <b>0.5</b>
+           <E units="cal/mol">-110.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH3O:1</reactants>
+      <products>CH3:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0067    -->
+    <reaction reversible="yes" id="0067">
+      <equation>H + CH3O [=] CH2(S) + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.620000E+11</A>
+           <b>-0.23</b>
+           <E units="cal/mol">1070.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH3O:1</reactants>
+      <products>CH2(S):1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0068    -->
+    <reaction reversible="yes" id="0068">
+      <equation>H + CH3OH [=] CH2OH + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.700000E+04</A>
+           <b>2.1</b>
+           <E units="cal/mol">4870.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3OH:1 H:1.0</reactants>
+      <products>H2:1 CH2OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0069    -->
+    <reaction reversible="yes" id="0069">
+      <equation>H + CH3OH [=] CH3O + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.200000E+03</A>
+           <b>2.1</b>
+           <E units="cal/mol">4870.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3OH:1 H:1.0</reactants>
+      <products>H2:1 CH3O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0070    -->
+    <reaction reversible="yes" type="falloff" id="0070">
+      <equation>H + C2H (+ M) [=] C2H2 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+14</A>
+           <b>-1</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>3.750000E+27</A>
+           <b>-4.8</b>
+           <E units="cal/mol">1900.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.6464 132 1315 5566 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 C2H:1</reactants>
+      <products>C2H2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0071    -->
+    <reaction reversible="yes" type="falloff" id="0071">
+      <equation>H + C2H2 (+ M) [=] C2H3 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.600000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">2400.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>3.800000E+34</A>
+           <b>-7.27</b>
+           <E units="cal/mol">7220.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.7507 98.5 1302 4167 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 C2H2:1</reactants>
+      <products>C2H3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0072    -->
+    <reaction reversible="yes" type="falloff" id="0072">
+      <equation>H + C2H3 (+ M) [=] C2H4 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.080000E+09</A>
+           <b>0.27</b>
+           <E units="cal/mol">280.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.400000E+24</A>
+           <b>-3.86</b>
+           <E units="cal/mol">3320.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.782 207.5 2663 6095 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 C2H3:1</reactants>
+      <products>C2H4:1.0</products>
+    </reaction>
+
+    <!-- reaction 0073    -->
+    <reaction reversible="yes" id="0073">
+      <equation>H + C2H3 [=] H2 + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 C2H3:1</reactants>
+      <products>H2:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0074    -->
+    <reaction reversible="yes" type="falloff" id="0074">
+      <equation>H + C2H4 (+ M) [=] C2H5 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.400000E+08</A>
+           <b>0.454</b>
+           <E units="cal/mol">1820.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>6.000000E+35</A>
+           <b>-7.62</b>
+           <E units="cal/mol">6970.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.9753 210 984 4374 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 C2H4:1</reactants>
+      <products>C2H5:1.0</products>
+    </reaction>
+
+    <!-- reaction 0075    -->
+    <reaction reversible="yes" id="0075">
+      <equation>H + C2H4 [=] C2H3 + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.325000E+03</A>
+           <b>2.53</b>
+           <E units="cal/mol">12240.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 C2H4:1</reactants>
+      <products>H2:1 C2H3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0076    -->
+    <reaction reversible="yes" type="falloff" id="0076">
+      <equation>H + C2H5 (+ M) [=] C2H6 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.210000E+14</A>
+           <b>-0.99</b>
+           <E units="cal/mol">1580.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.990000E+35</A>
+           <b>-7.08</b>
+           <E units="cal/mol">6685.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.8422 125 2219 6882 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 C2H5:1</reactants>
+      <products>C2H6:1.0</products>
+    </reaction>
+
+    <!-- reaction 0077    -->
+    <reaction reversible="yes" id="0077">
+      <equation>H + C2H5 [=] H2 + C2H4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 C2H5:1</reactants>
+      <products>H2:1.0 C2H4:1</products>
+    </reaction>
+
+    <!-- reaction 0078    -->
+    <reaction reversible="yes" id="0078">
+      <equation>H + C2H6 [=] C2H5 + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.150000E+05</A>
+           <b>1.9</b>
+           <E units="cal/mol">7530.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 C2H6:1</reactants>
+      <products>H2:1 C2H5:1.0</products>
+    </reaction>
+
+    <!-- reaction 0079    -->
+    <reaction reversible="yes" id="0079">
+      <equation>H + HCCO [=] CH2(S) + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 HCCO:1</reactants>
+      <products>CH2(S):1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0080    -->
+    <reaction reversible="yes" id="0080">
+      <equation>H + CH2CO [=] HCCO + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">8000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH2CO:1</reactants>
+      <products>H2:1 HCCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0081    -->
+    <reaction reversible="yes" id="0081">
+      <equation>H + CH2CO [=] CH3 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.130000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">3428.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH2CO:1</reactants>
+      <products>CH3:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0082    -->
+    <reaction reversible="yes" id="0082">
+      <equation>H + HCCOH [=] H + CH2CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 HCCOH:1</reactants>
+      <products>H:1.0 CH2CO:1</products>
+    </reaction>
+
+    <!-- reaction 0083    -->
+    <reaction reversible="yes" type="falloff" id="0083">
+      <equation>H2 + CO (+ M) [=] CH2O (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.300000E+04</A>
+           <b>1.5</b>
+           <E units="cal/mol">79600.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>5.070000E+21</A>
+           <b>-3.42</b>
+           <E units="cal/mol">84350.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.932 197 1540 10300 </falloff>
+      </rateCoeff>
+      <reactants>H2:1.0 CO:1</reactants>
+      <products>CH2O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0084    -->
+    <reaction reversible="yes" id="0084">
+      <equation>OH + H2 [=] H + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.160000E+05</A>
+           <b>1.51</b>
+           <E units="cal/mol">3430.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2:1 OH:1.0</reactants>
+      <products>H:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0085    -->
+    <reaction reversible="yes" type="falloff" id="0085">
+      <equation>2 OH (+ M) [=] H2O2 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.400000E+10</A>
+           <b>-0.37</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>2.300000E+12</A>
+           <b>-0.9</b>
+           <E units="cal/mol">-1700.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.7346 94 1756 5182 </falloff>
+      </rateCoeff>
+      <reactants>OH:2.0</reactants>
+      <products>H2O2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0086    -->
+    <reaction reversible="yes" id="0086">
+      <equation>2 OH [=] O + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.570000E+01</A>
+           <b>2.4</b>
+           <E units="cal/mol">-2110.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>OH:2.0</reactants>
+      <products>H2O:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0087    -->
+    <reaction duplicate="yes" reversible="yes" id="0087">
+      <equation>OH + HO2 [=] O2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.450000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">-500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HO2:1 OH:1.0</reactants>
+      <products>H2O:1 O2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0088    -->
+    <reaction duplicate="yes" reversible="yes" id="0088">
+      <equation>OH + H2O2 [=] HO2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">427.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2O2:1 OH:1.0</reactants>
+      <products>H2O:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0089    -->
+    <reaction duplicate="yes" reversible="yes" id="0089">
+      <equation>OH + H2O2 [=] HO2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.700000E+15</A>
+           <b>0</b>
+           <E units="cal/mol">29410.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2O2:1 OH:1.0</reactants>
+      <products>H2O:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0090    -->
+    <reaction reversible="yes" id="0090">
+      <equation>OH + C [=] H + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C:1 OH:1.0</reactants>
+      <products>H:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0091    -->
+    <reaction reversible="yes" id="0091">
+      <equation>OH + CH [=] H + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1 OH:1.0</reactants>
+      <products>H:1.0 HCO:1</products>
+    </reaction>
+
+    <!-- reaction 0092    -->
+    <reaction reversible="yes" id="0092">
+      <equation>OH + CH2 [=] H + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1 OH:1.0</reactants>
+      <products>CH2O:1 H:1.0</products>
+    </reaction>
+
+    <!-- reaction 0093    -->
+    <reaction reversible="yes" id="0093">
+      <equation>OH + CH2 [=] CH + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.130000E+04</A>
+           <b>2</b>
+           <E units="cal/mol">3000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1 OH:1.0</reactants>
+      <products>H2O:1 CH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0094    -->
+    <reaction reversible="yes" id="0094">
+      <equation>OH + CH2(S) [=] H + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1 OH:1.0</reactants>
+      <products>CH2O:1 H:1.0</products>
+    </reaction>
+
+    <!-- reaction 0095    -->
+    <reaction reversible="yes" type="falloff" id="0095">
+      <equation>OH + CH3 (+ M) [=] CH3OH (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.790000E+15</A>
+           <b>-1.43</b>
+           <E units="cal/mol">1330.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>4.000000E+30</A>
+           <b>-5.92</b>
+           <E units="cal/mol">3140.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.412 195 5900 6394 </falloff>
+      </rateCoeff>
+      <reactants>CH3:1 OH:1.0</reactants>
+      <products>CH3OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0096    -->
+    <reaction reversible="yes" id="0096">
+      <equation>OH + CH3 [=] CH2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.600000E+04</A>
+           <b>1.6</b>
+           <E units="cal/mol">5420.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 OH:1.0</reactants>
+      <products>CH2:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0097    -->
+    <reaction reversible="yes" id="0097">
+      <equation>OH + CH3 [=] CH2(S) + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.440000E+14</A>
+           <b>-1.34</b>
+           <E units="cal/mol">1417.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 OH:1.0</reactants>
+      <products>CH2(S):1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0098    -->
+    <reaction reversible="yes" id="0098">
+      <equation>OH + CH4 [=] CH3 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+05</A>
+           <b>1.6</b>
+           <E units="cal/mol">3120.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH4:1 OH:1.0</reactants>
+      <products>H2O:1 CH3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0099    -->
+    <reaction reversible="yes" id="0099">
+      <equation>OH + CO [=] H + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.760000E+04</A>
+           <b>1.228</b>
+           <E units="cal/mol">70.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CO:1 OH:1.0</reactants>
+      <products>H:1.0 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0100    -->
+    <reaction reversible="yes" id="0100">
+      <equation>OH + HCO [=] H2O + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCO:1 OH:1.0</reactants>
+      <products>H2O:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0101    -->
+    <reaction reversible="yes" id="0101">
+      <equation>OH + CH2O [=] HCO + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.430000E+06</A>
+           <b>1.18</b>
+           <E units="cal/mol">-447.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2O:1 OH:1.0</reactants>
+      <products>H2O:1 HCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0102    -->
+    <reaction reversible="yes" id="0102">
+      <equation>OH + CH2OH [=] H2O + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2OH:1 OH:1.0</reactants>
+      <products>CH2O:1 H2O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0103    -->
+    <reaction reversible="yes" id="0103">
+      <equation>OH + CH3O [=] H2O + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3O:1 OH:1.0</reactants>
+      <products>CH2O:1 H2O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0104    -->
+    <reaction reversible="yes" id="0104">
+      <equation>OH + CH3OH [=] CH2OH + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.440000E+03</A>
+           <b>2</b>
+           <E units="cal/mol">-840.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3OH:1 OH:1.0</reactants>
+      <products>CH2OH:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0105    -->
+    <reaction reversible="yes" id="0105">
+      <equation>OH + CH3OH [=] CH3O + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.300000E+03</A>
+           <b>2</b>
+           <E units="cal/mol">1500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3OH:1 OH:1.0</reactants>
+      <products>H2O:1 CH3O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0106    -->
+    <reaction reversible="yes" id="0106">
+      <equation>OH + C2H [=] H + HCCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H:1 OH:1.0</reactants>
+      <products>H:1.0 HCCO:1</products>
+    </reaction>
+
+    <!-- reaction 0107    -->
+    <reaction reversible="yes" id="0107">
+      <equation>OH + C2H2 [=] H + CH2CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.180000E-07</A>
+           <b>4.5</b>
+           <E units="cal/mol">-1000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H2:1 OH:1.0</reactants>
+      <products>H:1.0 CH2CO:1</products>
+    </reaction>
+
+    <!-- reaction 0108    -->
+    <reaction reversible="yes" id="0108">
+      <equation>OH + C2H2 [=] H + HCCOH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.040000E+02</A>
+           <b>2.3</b>
+           <E units="cal/mol">13500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H2:1 OH:1.0</reactants>
+      <products>H:1.0 HCCOH:1</products>
+    </reaction>
+
+    <!-- reaction 0109    -->
+    <reaction reversible="yes" id="0109">
+      <equation>OH + C2H2 [=] C2H + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.370000E+04</A>
+           <b>2</b>
+           <E units="cal/mol">14000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H2:1 OH:1.0</reactants>
+      <products>C2H:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0110    -->
+    <reaction reversible="yes" id="0110">
+      <equation>OH + C2H2 [=] CH3 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.830000E-07</A>
+           <b>4</b>
+           <E units="cal/mol">-2000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H2:1 OH:1.0</reactants>
+      <products>CH3:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0111    -->
+    <reaction reversible="yes" id="0111">
+      <equation>OH + C2H3 [=] H2O + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H3:1 OH:1.0</reactants>
+      <products>H2O:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0112    -->
+    <reaction reversible="yes" id="0112">
+      <equation>OH + C2H4 [=] C2H3 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.600000E+03</A>
+           <b>2</b>
+           <E units="cal/mol">2500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H4:1 OH:1.0</reactants>
+      <products>H2O:1 C2H3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0113    -->
+    <reaction reversible="yes" id="0113">
+      <equation>OH + C2H6 [=] C2H5 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.540000E+03</A>
+           <b>2.12</b>
+           <E units="cal/mol">870.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H6:1 OH:1.0</reactants>
+      <products>C2H5:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0114    -->
+    <reaction reversible="yes" id="0114">
+      <equation>OH + CH2CO [=] HCCO + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.500000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">2000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2CO:1 OH:1.0</reactants>
+      <products>H2O:1 HCCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0115    -->
+    <reaction duplicate="yes" reversible="yes" id="0115">
+      <equation>2 HO2 [=] O2 + H2O2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.300000E+08</A>
+           <b>0</b>
+           <E units="cal/mol">-1630.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HO2:2.0</reactants>
+      <products>O2:1.0 H2O2:1</products>
+    </reaction>
+
+    <!-- reaction 0116    -->
+    <reaction duplicate="yes" reversible="yes" id="0116">
+      <equation>2 HO2 [=] O2 + H2O2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.200000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">12000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HO2:2.0</reactants>
+      <products>O2:1.0 H2O2:1</products>
+    </reaction>
+
+    <!-- reaction 0117    -->
+    <reaction reversible="yes" id="0117">
+      <equation>HO2 + CH2 [=] OH + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1 HO2:1.0</reactants>
+      <products>CH2O:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0118    -->
+    <reaction reversible="yes" id="0118">
+      <equation>HO2 + CH3 [=] O2 + CH4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 HO2:1.0</reactants>
+      <products>CH4:1 O2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0119    -->
+    <reaction reversible="yes" id="0119">
+      <equation>HO2 + CH3 [=] OH + CH3O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.780000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 HO2:1.0</reactants>
+      <products>CH3O:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0120    -->
+    <reaction reversible="yes" id="0120">
+      <equation>HO2 + CO [=] OH + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">23600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CO:1 HO2:1.0</reactants>
+      <products>CO2:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0121    -->
+    <reaction reversible="yes" id="0121">
+      <equation>HO2 + CH2O [=] HCO + H2O2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.600000E+03</A>
+           <b>2</b>
+           <E units="cal/mol">12000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2O:1 HO2:1.0</reactants>
+      <products>HCO:1.0 H2O2:1</products>
+    </reaction>
+
+    <!-- reaction 0122    -->
+    <reaction reversible="yes" id="0122">
+      <equation>C + O2 [=] O + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.800000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">576.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C:1.0 O2:1</reactants>
+      <products>CO:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0123    -->
+    <reaction reversible="yes" id="0123">
+      <equation>C + CH2 [=] H + C2H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C:1.0 CH2:1</reactants>
+      <products>H:1.0 C2H:1</products>
+    </reaction>
+
+    <!-- reaction 0124    -->
+    <reaction reversible="yes" id="0124">
+      <equation>C + CH3 [=] H + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C:1.0 CH3:1</reactants>
+      <products>H:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0125    -->
+    <reaction reversible="yes" id="0125">
+      <equation>CH + O2 [=] O + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.710000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1.0 O2:1</reactants>
+      <products>HCO:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0126    -->
+    <reaction reversible="yes" id="0126">
+      <equation>CH + H2 [=] H + CH2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.080000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">3110.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2:1 CH:1.0</reactants>
+      <products>H:1.0 CH2:1</products>
+    </reaction>
+
+    <!-- reaction 0127    -->
+    <reaction reversible="yes" id="0127">
+      <equation>CH + H2O [=] H + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.710000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">-755.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2O:1 CH:1.0</reactants>
+      <products>CH2O:1 H:1.0</products>
+    </reaction>
+
+    <!-- reaction 0128    -->
+    <reaction reversible="yes" id="0128">
+      <equation>CH + CH2 [=] H + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1 CH:1.0</reactants>
+      <products>H:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0129    -->
+    <reaction reversible="yes" id="0129">
+      <equation>CH + CH3 [=] H + C2H3</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 CH:1.0</reactants>
+      <products>H:1.0 C2H3:1</products>
+    </reaction>
+
+    <!-- reaction 0130    -->
+    <reaction reversible="yes" id="0130">
+      <equation>CH + CH4 [=] H + C2H4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1.0 CH4:1</reactants>
+      <products>H:1.0 C2H4:1</products>
+    </reaction>
+
+    <!-- reaction 0131    -->
+    <reaction reversible="yes" type="falloff" id="0131">
+      <equation>CH + CO (+ M) [=] HCCO (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>2.690000E+22</A>
+           <b>-3.74</b>
+           <E units="cal/mol">1936.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.5757 237 1652 5069 </falloff>
+      </rateCoeff>
+      <reactants>CH:1.0 CO:1</reactants>
+      <products>HCCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0132    -->
+    <reaction reversible="yes" id="0132">
+      <equation>CH + CO2 [=] HCO + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.900000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">15792.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1.0 CO2:1</reactants>
+      <products>CO:1 HCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0133    -->
+    <reaction reversible="yes" id="0133">
+      <equation>CH + CH2O [=] H + CH2CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.460000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">-515.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2O:1 CH:1.0</reactants>
+      <products>H:1.0 CH2CO:1</products>
+    </reaction>
+
+    <!-- reaction 0134    -->
+    <reaction reversible="yes" id="0134">
+      <equation>CH + HCCO [=] CO + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1.0 HCCO:1</reactants>
+      <products>CO:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0135    -->
+    <reaction reversible="no" id="0135">
+      <equation>CH2 + O2 =] OH + H + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">1500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 O2:1</reactants>
+      <products>H:1 CO:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0136    -->
+    <reaction reversible="yes" id="0136">
+      <equation>CH2 + H2 [=] H + CH3</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+02</A>
+           <b>2</b>
+           <E units="cal/mol">7230.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2:1 CH2:1.0</reactants>
+      <products>H:1.0 CH3:1</products>
+    </reaction>
+
+    <!-- reaction 0137    -->
+    <reaction reversible="yes" id="0137">
+      <equation>2 CH2 [=] H2 + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.600000E+12</A>
+           <b>0</b>
+           <E units="cal/mol">11944.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:2.0</reactants>
+      <products>H2:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0138    -->
+    <reaction reversible="yes" id="0138">
+      <equation>CH2 + CH3 [=] H + C2H4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 CH3:1</reactants>
+      <products>H:1.0 C2H4:1</products>
+    </reaction>
+
+    <!-- reaction 0139    -->
+    <reaction reversible="yes" id="0139">
+      <equation>CH2 + CH4 [=] 2 CH3</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.460000E+03</A>
+           <b>2</b>
+           <E units="cal/mol">8270.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 CH4:1</reactants>
+      <products>CH3:2.0</products>
+    </reaction>
+
+    <!-- reaction 0140    -->
+    <reaction reversible="yes" type="falloff" id="0140">
+      <equation>CH2 + CO (+ M) [=] CH2CO (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>8.100000E+08</A>
+           <b>0.5</b>
+           <E units="cal/mol">4510.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>2.690000E+27</A>
+           <b>-5.11</b>
+           <E units="cal/mol">7095.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.5907 275 1226 5185 </falloff>
+      </rateCoeff>
+      <reactants>CH2:1.0 CO:1</reactants>
+      <products>CH2CO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0141    -->
+    <reaction reversible="yes" id="0141">
+      <equation>CH2 + HCCO [=] C2H3 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 HCCO:1</reactants>
+      <products>CO:1 C2H3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0142    -->
+    <reaction reversible="yes" id="0142">
+      <equation>CH2(S) + N2 [=] CH2 + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 N2:1</reactants>
+      <products>CH2:1.0 N2:1</products>
+    </reaction>
+
+    <!-- reaction 0143    -->
+    <reaction reversible="yes" id="0143">
+      <equation>CH2(S) + AR [=] CH2 + AR</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 AR:1</reactants>
+      <products>CH2:1.0 AR:1</products>
+    </reaction>
+
+    <!-- reaction 0144    -->
+    <reaction reversible="yes" id="0144">
+      <equation>CH2(S) + O2 [=] H + OH + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.800000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 O2:1</reactants>
+      <products>H:1.0 CO:1 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0145    -->
+    <reaction reversible="yes" id="0145">
+      <equation>CH2(S) + O2 [=] CO + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.200000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 O2:1</reactants>
+      <products>H2O:1 CO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0146    -->
+    <reaction reversible="yes" id="0146">
+      <equation>CH2(S) + H2 [=] CH3 + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2:1 CH2(S):1.0</reactants>
+      <products>H:1 CH3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0147    -->
+    <reaction reversible="yes" type="falloff" id="0147">
+      <equation>CH2(S) + H2O (+ M) [=] CH3OH (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.820000E+14</A>
+           <b>-1.16</b>
+           <E units="cal/mol">1145.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.880000E+32</A>
+           <b>-6.36</b>
+           <E units="cal/mol">5040.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.6027 208 3922 10180 </falloff>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 H2O:1</reactants>
+      <products>CH3OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0148    -->
+    <reaction reversible="yes" id="0148">
+      <equation>CH2(S) + H2O [=] CH2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 H2O:1</reactants>
+      <products>CH2:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0149    -->
+    <reaction reversible="yes" id="0149">
+      <equation>CH2(S) + CH3 [=] H + C2H4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.200000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">-570.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 CH3:1</reactants>
+      <products>H:1.0 C2H4:1</products>
+    </reaction>
+
+    <!-- reaction 0150    -->
+    <reaction reversible="yes" id="0150">
+      <equation>CH2(S) + CH4 [=] 2 CH3</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.600000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">-570.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 CH4:1</reactants>
+      <products>CH3:2.0</products>
+    </reaction>
+
+    <!-- reaction 0151    -->
+    <reaction reversible="yes" id="0151">
+      <equation>CH2(S) + CO [=] CH2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 CO:1</reactants>
+      <products>CH2:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0152    -->
+    <reaction reversible="yes" id="0152">
+      <equation>CH2(S) + CO2 [=] CH2 + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 CO2:1</reactants>
+      <products>CH2:1.0 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0153    -->
+    <reaction reversible="yes" id="0153">
+      <equation>CH2(S) + CO2 [=] CO + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.400000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 CO2:1</reactants>
+      <products>CH2O:1 CO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0154    -->
+    <reaction reversible="yes" id="0154">
+      <equation>CH2(S) + C2H6 [=] CH3 + C2H5</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">-550.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 C2H6:1</reactants>
+      <products>C2H5:1 CH3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0155    -->
+    <reaction reversible="yes" id="0155">
+      <equation>CH3 + O2 [=] O + CH3O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.560000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">30480.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 O2:1</reactants>
+      <products>CH3O:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0156    -->
+    <reaction reversible="yes" id="0156">
+      <equation>CH3 + O2 [=] OH + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.310000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">20315.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 O2:1</reactants>
+      <products>CH2O:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0157    -->
+    <reaction reversible="yes" id="0157">
+      <equation>CH3 + H2O2 [=] HO2 + CH4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.450000E+01</A>
+           <b>2.47</b>
+           <E units="cal/mol">5180.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 H2O2:1</reactants>
+      <products>CH4:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0158    -->
+    <reaction reversible="yes" type="falloff" id="0158">
+      <equation>2 CH3 (+ M) [=] C2H6 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.770000E+13</A>
+           <b>-1.18</b>
+           <E units="cal/mol">654.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>3.400000E+35</A>
+           <b>-7.03</b>
+           <E units="cal/mol">2762.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.619 73.2 1180 9999 </falloff>
+      </rateCoeff>
+      <reactants>CH3:2.0</reactants>
+      <products>C2H6:1.0</products>
+    </reaction>
+
+    <!-- reaction 0159    -->
+    <reaction reversible="yes" id="0159">
+      <equation>2 CH3 [=] H + C2H5</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.840000E+09</A>
+           <b>0.1</b>
+           <E units="cal/mol">10600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:2.0</reactants>
+      <products>H:1.0 C2H5:1</products>
+    </reaction>
+
+    <!-- reaction 0160    -->
+    <reaction reversible="yes" id="0160">
+      <equation>CH3 + HCO [=] CH4 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.648000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 HCO:1</reactants>
+      <products>CO:1 CH4:1.0</products>
+    </reaction>
+
+    <!-- reaction 0161    -->
+    <reaction reversible="yes" id="0161">
+      <equation>CH3 + CH2O [=] HCO + CH4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.320000E+00</A>
+           <b>2.81</b>
+           <E units="cal/mol">5860.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2O:1 CH3:1.0</reactants>
+      <products>CH4:1 HCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0162    -->
+    <reaction reversible="yes" id="0162">
+      <equation>CH3 + CH3OH [=] CH2OH + CH4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+04</A>
+           <b>1.5</b>
+           <E units="cal/mol">9940.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3OH:1 CH3:1.0</reactants>
+      <products>CH2OH:1.0 CH4:1</products>
+    </reaction>
+
+    <!-- reaction 0163    -->
+    <reaction reversible="yes" id="0163">
+      <equation>CH3 + CH3OH [=] CH3O + CH4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+04</A>
+           <b>1.5</b>
+           <E units="cal/mol">9940.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3OH:1 CH3:1.0</reactants>
+      <products>CH3O:1.0 CH4:1</products>
+    </reaction>
+
+    <!-- reaction 0164    -->
+    <reaction reversible="yes" id="0164">
+      <equation>CH3 + C2H4 [=] C2H3 + CH4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.270000E+02</A>
+           <b>2</b>
+           <E units="cal/mol">9200.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 C2H4:1</reactants>
+      <products>CH4:1 C2H3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0165    -->
+    <reaction reversible="yes" id="0165">
+      <equation>CH3 + C2H6 [=] C2H5 + CH4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.140000E+03</A>
+           <b>1.74</b>
+           <E units="cal/mol">10450.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H6:1 CH3:1.0</reactants>
+      <products>C2H5:1.0 CH4:1</products>
+    </reaction>
+
+    <!-- reaction 0166    -->
+    <reaction reversible="yes" id="0166">
+      <equation>HCO + H2O [=] H + CO + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+15</A>
+           <b>-1</b>
+           <E units="cal/mol">17000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2O:1 HCO:1.0</reactants>
+      <products>H:1.0 H2O:1 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0167    -->
+    <reaction reversible="yes" type="threeBody" id="0167">
+      <equation>HCO + M [=] H + CO + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.870000E+14</A>
+           <b>-1</b>
+           <E units="cal/mol">17000.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:0 </efficiencies>
+      </rateCoeff>
+      <reactants>HCO:1.0</reactants>
+      <products>H:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0168    -->
+    <reaction reversible="yes" id="0168">
+      <equation>HCO + O2 [=] HO2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.345000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">400.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCO:1.0 O2:1</reactants>
+      <products>CO:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0169    -->
+    <reaction reversible="yes" id="0169">
+      <equation>CH2OH + O2 [=] HO2 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.800000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">900.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2OH:1.0 O2:1</reactants>
+      <products>CH2O:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0170    -->
+    <reaction reversible="yes" id="0170">
+      <equation>CH3O + O2 [=] HO2 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.280000E-16</A>
+           <b>7.6</b>
+           <E units="cal/mol">-3530.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3O:1.0 O2:1</reactants>
+      <products>CH2O:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0171    -->
+    <reaction reversible="yes" id="0171">
+      <equation>C2H + O2 [=] HCO + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">-755.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H:1.0 O2:1</reactants>
+      <products>CO:1 HCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0172    -->
+    <reaction reversible="yes" id="0172">
+      <equation>C2H + H2 [=] H + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.680000E+07</A>
+           <b>0.9</b>
+           <E units="cal/mol">1993.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2:1 C2H:1.0</reactants>
+      <products>H:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0173    -->
+    <reaction reversible="yes" id="0173">
+      <equation>C2H3 + O2 [=] HCO + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.580000E+13</A>
+           <b>-1.39</b>
+           <E units="cal/mol">1015.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H3:1.0 O2:1</reactants>
+      <products>CH2O:1 HCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0174    -->
+    <reaction reversible="yes" type="falloff" id="0174">
+      <equation>C2H4 (+ M) [=] H2 + C2H2 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>8.000000E+12</A>
+           <b>0.44</b>
+           <E units="cal/mol">86770.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.580000E+48</A>
+           <b>-9.3</b>
+           <E units="cal/mol">97800.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.7345 180 1035 5417 </falloff>
+      </rateCoeff>
+      <reactants>C2H4:1.0</reactants>
+      <products>H2:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0175    -->
+    <reaction reversible="yes" id="0175">
+      <equation>C2H5 + O2 [=] HO2 + C2H4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>8.400000E+08</A>
+           <b>0</b>
+           <E units="cal/mol">3875.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H5:1.0 O2:1</reactants>
+      <products>C2H4:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0176    -->
+    <reaction reversible="yes" id="0176">
+      <equation>HCCO + O2 [=] OH + 2 CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.200000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">854.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCCO:1.0 O2:1</reactants>
+      <products>CO:2.0 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0177    -->
+    <reaction reversible="yes" id="0177">
+      <equation>2 HCCO [=] 2 CO + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCCO:2.0</reactants>
+      <products>CO:2.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0178    -->
+    <reaction reversible="yes" id="0178">
+      <equation>N + NO [=] N2 + O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.700000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">355.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NO:1 N:1.0</reactants>
+      <products>N2:1.0 O:1</products>
+    </reaction>
+
+    <!-- reaction 0179    -->
+    <reaction reversible="yes" id="0179">
+      <equation>N + O2 [=] NO + O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.000000E+06</A>
+           <b>1</b>
+           <E units="cal/mol">6500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O2:1 N:1.0</reactants>
+      <products>O:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0180    -->
+    <reaction reversible="yes" id="0180">
+      <equation>N + OH [=] NO + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.360000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">385.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>OH:1 N:1.0</reactants>
+      <products>H:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0181    -->
+    <reaction reversible="yes" id="0181">
+      <equation>N2O + O [=] N2 + O2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.400000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">10810.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>N2O:1.0 O:1</reactants>
+      <products>N2:1.0 O2:1</products>
+    </reaction>
+
+    <!-- reaction 0182    -->
+    <reaction reversible="yes" id="0182">
+      <equation>N2O + O [=] 2 NO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.900000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">23150.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>N2O:1.0 O:1</reactants>
+      <products>NO:2.0</products>
+    </reaction>
+
+    <!-- reaction 0183    -->
+    <reaction reversible="yes" id="0183">
+      <equation>N2O + H [=] N2 + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.870000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">18880.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 N2O:1.0</reactants>
+      <products>N2:1.0 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0184    -->
+    <reaction reversible="yes" id="0184">
+      <equation>N2O + OH [=] N2 + HO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">21060.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>N2O:1.0 OH:1</reactants>
+      <products>N2:1.0 HO2:1</products>
+    </reaction>
+
+    <!-- reaction 0185    -->
+    <reaction reversible="yes" type="falloff" id="0185">
+      <equation>N2O (+ M) [=] N2 + O (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.910000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">56020.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>6.370000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">56640.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.625  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Lindemann"/>
+      </rateCoeff>
+      <reactants>N2O:1.0</reactants>
+      <products>N2:1.0 O:1</products>
+    </reaction>
+
+    <!-- reaction 0186    -->
+    <reaction reversible="yes" id="0186">
+      <equation>HO2 + NO [=] NO2 + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.110000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">-480.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HO2:1.0 NO:1</reactants>
+      <products>NO2:1.0 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0187    -->
+    <reaction reversible="yes" type="threeBody" id="0187">
+      <equation>NO + O + M [=] NO2 + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.060000E+14</A>
+           <b>-1.41</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+      </rateCoeff>
+      <reactants>O:1 NO:1.0</reactants>
+      <products>NO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0188    -->
+    <reaction reversible="yes" id="0188">
+      <equation>NO2 + O [=] NO + O2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.900000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">-240.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 NO2:1.0</reactants>
+      <products>O2:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0189    -->
+    <reaction reversible="yes" id="0189">
+      <equation>NO2 + H [=] NO + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.320000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">360.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 NO2:1.0</reactants>
+      <products>OH:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0190    -->
+    <reaction reversible="yes" id="0190">
+      <equation>NH + O [=] NO + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 O:1</reactants>
+      <products>H:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0191    -->
+    <reaction reversible="yes" id="0191">
+      <equation>NH + H [=] N + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.200000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">330.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 H:1</reactants>
+      <products>H2:1 N:1.0</products>
+    </reaction>
+
+    <!-- reaction 0192    -->
+    <reaction reversible="yes" id="0192">
+      <equation>NH + OH [=] HNO + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 OH:1</reactants>
+      <products>H:1 HNO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0193    -->
+    <reaction reversible="yes" id="0193">
+      <equation>NH + OH [=] N + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+06</A>
+           <b>1.2</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 OH:1</reactants>
+      <products>H2O:1 N:1.0</products>
+    </reaction>
+
+    <!-- reaction 0194    -->
+    <reaction reversible="yes" id="0194">
+      <equation>NH + O2 [=] HNO + O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.610000E+02</A>
+           <b>2</b>
+           <E units="cal/mol">6500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 O2:1</reactants>
+      <products>O:1 HNO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0195    -->
+    <reaction reversible="yes" id="0195">
+      <equation>NH + O2 [=] NO + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.280000E+03</A>
+           <b>1.5</b>
+           <E units="cal/mol">100.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 O2:1</reactants>
+      <products>OH:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0196    -->
+    <reaction reversible="yes" id="0196">
+      <equation>NH + N [=] N2 + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 N:1</reactants>
+      <products>H:1 N2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0197    -->
+    <reaction reversible="yes" id="0197">
+      <equation>NH + H2O [=] HNO + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">13850.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 H2O:1</reactants>
+      <products>H2:1 HNO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0198    -->
+    <reaction reversible="yes" id="0198">
+      <equation>NH + NO [=] N2 + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.160000E+10</A>
+           <b>-0.23</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 NO:1</reactants>
+      <products>N2:1.0 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0199    -->
+    <reaction reversible="yes" id="0199">
+      <equation>NH + NO [=] N2O + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.650000E+11</A>
+           <b>-0.45</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 NO:1</reactants>
+      <products>H:1 N2O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0200    -->
+    <reaction reversible="yes" id="0200">
+      <equation>NH2 + O [=] OH + NH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 NH2:1.0</reactants>
+      <products>NH:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0201    -->
+    <reaction reversible="yes" id="0201">
+      <equation>NH2 + O [=] H + HNO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.900000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 NH2:1.0</reactants>
+      <products>H:1.0 HNO:1</products>
+    </reaction>
+
+    <!-- reaction 0202    -->
+    <reaction reversible="yes" id="0202">
+      <equation>NH2 + H [=] NH + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">3650.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 NH2:1.0</reactants>
+      <products>NH:1.0 H2:1</products>
+    </reaction>
+
+    <!-- reaction 0203    -->
+    <reaction reversible="yes" id="0203">
+      <equation>NH2 + OH [=] NH + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.000000E+04</A>
+           <b>1.5</b>
+           <E units="cal/mol">-460.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>OH:1 NH2:1.0</reactants>
+      <products>NH:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0204    -->
+    <reaction reversible="yes" id="0204">
+      <equation>NNH [=] N2 + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.300000E+08</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NNH:1.0</reactants>
+      <products>H:1 N2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0205    -->
+    <reaction reversible="yes" type="threeBody" id="0205">
+      <equation>NNH + M [=] N2 + H + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.300000E+11</A>
+           <b>-0.11</b>
+           <E units="cal/mol">4980.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+      </rateCoeff>
+      <reactants>NNH:1.0</reactants>
+      <products>H:1 N2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0206    -->
+    <reaction reversible="yes" id="0206">
+      <equation>NNH + O2 [=] HO2 + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O2:1 NNH:1.0</reactants>
+      <products>N2:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0207    -->
+    <reaction reversible="yes" id="0207">
+      <equation>NNH + O [=] OH + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.500000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 NNH:1.0</reactants>
+      <products>N2:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0208    -->
+    <reaction reversible="yes" id="0208">
+      <equation>NNH + O [=] NH + NO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 NNH:1.0</reactants>
+      <products>NH:1.0 NO:1</products>
+    </reaction>
+
+    <!-- reaction 0209    -->
+    <reaction reversible="yes" id="0209">
+      <equation>NNH + H [=] H2 + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 NNH:1.0</reactants>
+      <products>H2:1.0 N2:1</products>
+    </reaction>
+
+    <!-- reaction 0210    -->
+    <reaction reversible="yes" id="0210">
+      <equation>NNH + OH [=] H2O + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>OH:1 NNH:1.0</reactants>
+      <products>H2O:1.0 N2:1</products>
+    </reaction>
+
+    <!-- reaction 0211    -->
+    <reaction reversible="yes" id="0211">
+      <equation>NNH + CH3 [=] CH4 + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.500000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 NNH:1.0</reactants>
+      <products>N2:1 CH4:1.0</products>
+    </reaction>
+
+    <!-- reaction 0212    -->
+    <reaction reversible="yes" type="threeBody" id="0212">
+      <equation>H + NO + M [=] HNO + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.480000E+13</A>
+           <b>-1.32</b>
+           <E units="cal/mol">740.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+      </rateCoeff>
+      <reactants>H:1.0 NO:1</reactants>
+      <products>HNO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0213    -->
+    <reaction reversible="yes" id="0213">
+      <equation>HNO + O [=] NO + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.500000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 HNO:1.0</reactants>
+      <products>OH:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0214    -->
+    <reaction reversible="yes" id="0214">
+      <equation>HNO + H [=] H2 + NO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.000000E+08</A>
+           <b>0.72</b>
+           <E units="cal/mol">660.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 HNO:1.0</reactants>
+      <products>H2:1.0 NO:1</products>
+    </reaction>
+
+    <!-- reaction 0215    -->
+    <reaction reversible="yes" id="0215">
+      <equation>HNO + OH [=] NO + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.300000E+04</A>
+           <b>1.9</b>
+           <E units="cal/mol">-950.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HNO:1.0 OH:1</reactants>
+      <products>H2O:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0216    -->
+    <reaction reversible="yes" id="0216">
+      <equation>HNO + O2 [=] HO2 + NO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">13000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O2:1 HNO:1.0</reactants>
+      <products>HO2:1.0 NO:1</products>
+    </reaction>
+
+    <!-- reaction 0217    -->
+    <reaction reversible="yes" id="0217">
+      <equation>CN + O [=] CO + N</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>7.700000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CN:1.0 O:1</reactants>
+      <products>CO:1.0 N:1</products>
+    </reaction>
+
+    <!-- reaction 0218    -->
+    <reaction reversible="yes" id="0218">
+      <equation>CN + OH [=] NCO + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CN:1.0 OH:1</reactants>
+      <products>H:1 NCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0219    -->
+    <reaction reversible="yes" id="0219">
+      <equation>CN + H2O [=] HCN + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>8.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">7460.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2O:1 CN:1.0</reactants>
+      <products>HCN:1.0 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0220    -->
+    <reaction reversible="yes" id="0220">
+      <equation>CN + O2 [=] NCO + O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.140000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">-440.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CN:1.0 O2:1</reactants>
+      <products>O:1 NCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0221    -->
+    <reaction reversible="yes" id="0221">
+      <equation>CN + H2 [=] HCN + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.950000E+02</A>
+           <b>2.45</b>
+           <E units="cal/mol">2240.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2:1 CN:1.0</reactants>
+      <products>H:1 HCN:1.0</products>
+    </reaction>
+
+    <!-- reaction 0222    -->
+    <reaction reversible="yes" id="0222">
+      <equation>NCO + O [=] NO + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.350000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 NCO:1.0</reactants>
+      <products>CO:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0223    -->
+    <reaction reversible="yes" id="0223">
+      <equation>NCO + H [=] NH + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.400000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 NCO:1.0</reactants>
+      <products>NH:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0224    -->
+    <reaction reversible="yes" id="0224">
+      <equation>NCO + OH [=] NO + H + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.500000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>OH:1 NCO:1.0</reactants>
+      <products>H:1 CO:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0225    -->
+    <reaction reversible="yes" id="0225">
+      <equation>NCO + N [=] N2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>N:1 NCO:1.0</reactants>
+      <products>N2:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0226    -->
+    <reaction reversible="yes" id="0226">
+      <equation>NCO + O2 [=] NO + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">20000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O2:1 NCO:1.0</reactants>
+      <products>CO2:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0227    -->
+    <reaction reversible="yes" type="threeBody" id="0227">
+      <equation>NCO + M [=] N + CO + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.100000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">54050.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+      </rateCoeff>
+      <reactants>NCO:1.0</reactants>
+      <products>CO:1 N:1.0</products>
+    </reaction>
+
+    <!-- reaction 0228    -->
+    <reaction reversible="yes" id="0228">
+      <equation>NCO + NO [=] N2O + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.900000E+14</A>
+           <b>-1.52</b>
+           <E units="cal/mol">740.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NO:1 NCO:1.0</reactants>
+      <products>CO:1 N2O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0229    -->
+    <reaction reversible="yes" id="0229">
+      <equation>NCO + NO [=] N2 + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.800000E+15</A>
+           <b>-2</b>
+           <E units="cal/mol">800.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NO:1 NCO:1.0</reactants>
+      <products>N2:1.0 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0230    -->
+    <reaction reversible="yes" type="threeBody" id="0230">
+      <equation>HCN + M [=] H + CN + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.040000E+26</A>
+           <b>-3.3</b>
+           <E units="cal/mol">126600.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+      </rateCoeff>
+      <reactants>HCN:1.0</reactants>
+      <products>H:1.0 CN:1</products>
+    </reaction>
+
+    <!-- reaction 0231    -->
+    <reaction reversible="yes" id="0231">
+      <equation>HCN + O [=] NCO + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.030000E+01</A>
+           <b>2.64</b>
+           <E units="cal/mol">4980.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCN:1.0 O:1</reactants>
+      <products>H:1 NCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0232    -->
+    <reaction reversible="yes" id="0232">
+      <equation>HCN + O [=] NH + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.070000E+00</A>
+           <b>2.64</b>
+           <E units="cal/mol">4980.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCN:1.0 O:1</reactants>
+      <products>NH:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0233    -->
+    <reaction reversible="yes" id="0233">
+      <equation>HCN + O [=] CN + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.910000E+06</A>
+           <b>1.58</b>
+           <E units="cal/mol">26600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCN:1.0 O:1</reactants>
+      <products>CN:1.0 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0234    -->
+    <reaction reversible="yes" id="0234">
+      <equation>HCN + OH [=] HOCN + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.100000E+03</A>
+           <b>2.03</b>
+           <E units="cal/mol">13370.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCN:1.0 OH:1</reactants>
+      <products>HOCN:1.0 H:1</products>
+    </reaction>
+
+    <!-- reaction 0235    -->
+    <reaction reversible="yes" id="0235">
+      <equation>HCN + OH [=] HNCO + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.400000E+00</A>
+           <b>2.26</b>
+           <E units="cal/mol">6400.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCN:1.0 OH:1</reactants>
+      <products>HNCO:1.0 H:1</products>
+    </reaction>
+
+    <!-- reaction 0236    -->
+    <reaction reversible="yes" id="0236">
+      <equation>HCN + OH [=] NH2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.600000E-01</A>
+           <b>2.56</b>
+           <E units="cal/mol">9000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCN:1.0 OH:1</reactants>
+      <products>CO:1 NH2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0237    -->
+    <reaction reversible="yes" type="falloff" id="0237">
+      <equation>H + HCN (+ M) [=] H2CN (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.300000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.400000E+20</A>
+           <b>-3.4</b>
+           <E units="cal/mol">1900.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Lindemann"/>
+      </rateCoeff>
+      <reactants>H:1.0 HCN:1</reactants>
+      <products>H2CN:1.0</products>
+    </reaction>
+
+    <!-- reaction 0238    -->
+    <reaction reversible="yes" id="0238">
+      <equation>H2CN + N [=] N2 + CH2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">400.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H2CN:1.0 N:1</reactants>
+      <products>N2:1.0 CH2:1</products>
+    </reaction>
+
+    <!-- reaction 0239    -->
+    <reaction reversible="yes" id="0239">
+      <equation>C + N2 [=] CN + N</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.300000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">46020.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C:1.0 N2:1</reactants>
+      <products>CN:1.0 N:1</products>
+    </reaction>
+
+    <!-- reaction 0240    -->
+    <reaction reversible="yes" id="0240">
+      <equation>CH + N2 [=] HCN + N</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.120000E+06</A>
+           <b>0.88</b>
+           <E units="cal/mol">20130.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>N2:1 CH:1.0</reactants>
+      <products>HCN:1.0 N:1</products>
+    </reaction>
+
+    <!-- reaction 0241    -->
+    <reaction reversible="yes" type="falloff" id="0241">
+      <equation>CH + N2 (+ M) [=] HCNN (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.100000E+09</A>
+           <b>0.15</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.300000E+19</A>
+           <b>-3.16</b>
+           <E units="cal/mol">740.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:1  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.667 235 2117 4536 </falloff>
+      </rateCoeff>
+      <reactants>N2:1 CH:1.0</reactants>
+      <products>HCNN:1.0</products>
+    </reaction>
+
+    <!-- reaction 0242    -->
+    <reaction reversible="yes" id="0242">
+      <equation>CH2 + N2 [=] HCN + NH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">74000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 N2:1</reactants>
+      <products>NH:1 HCN:1.0</products>
+    </reaction>
+
+    <!-- reaction 0243    -->
+    <reaction reversible="yes" id="0243">
+      <equation>CH2(S) + N2 [=] NH + HCN</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+08</A>
+           <b>0</b>
+           <E units="cal/mol">65000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 N2:1</reactants>
+      <products>NH:1.0 HCN:1</products>
+    </reaction>
+
+    <!-- reaction 0244    -->
+    <reaction reversible="yes" id="0244">
+      <equation>C + NO [=] CN + O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.900000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C:1.0 NO:1</reactants>
+      <products>CN:1.0 O:1</products>
+    </reaction>
+
+    <!-- reaction 0245    -->
+    <reaction reversible="yes" id="0245">
+      <equation>C + NO [=] CO + N</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.900000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C:1.0 NO:1</reactants>
+      <products>CO:1.0 N:1</products>
+    </reaction>
+
+    <!-- reaction 0246    -->
+    <reaction reversible="yes" id="0246">
+      <equation>CH + NO [=] HCN + O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.100000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1.0 NO:1</reactants>
+      <products>HCN:1.0 O:1</products>
+    </reaction>
+
+    <!-- reaction 0247    -->
+    <reaction reversible="yes" id="0247">
+      <equation>CH + NO [=] H + NCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.620000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1.0 NO:1</reactants>
+      <products>H:1.0 NCO:1</products>
+    </reaction>
+
+    <!-- reaction 0248    -->
+    <reaction reversible="yes" id="0248">
+      <equation>CH + NO [=] N + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.460000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH:1.0 NO:1</reactants>
+      <products>HCO:1 N:1.0</products>
+    </reaction>
+
+    <!-- reaction 0249    -->
+    <reaction reversible="yes" id="0249">
+      <equation>CH2 + NO [=] H + HNCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.100000E+14</A>
+           <b>-1.38</b>
+           <E units="cal/mol">1270.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 NO:1</reactants>
+      <products>HNCO:1 H:1.0</products>
+    </reaction>
+
+    <!-- reaction 0250    -->
+    <reaction reversible="yes" id="0250">
+      <equation>CH2 + NO [=] OH + HCN</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.900000E+11</A>
+           <b>-0.69</b>
+           <E units="cal/mol">760.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 NO:1</reactants>
+      <products>HCN:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0251    -->
+    <reaction reversible="yes" id="0251">
+      <equation>CH2 + NO [=] H + HCNO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.800000E+10</A>
+           <b>-0.36</b>
+           <E units="cal/mol">580.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 NO:1</reactants>
+      <products>H:1.0 HCNO:1</products>
+    </reaction>
+
+    <!-- reaction 0252    -->
+    <reaction reversible="yes" id="0252">
+      <equation>CH2(S) + NO [=] H + HNCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.100000E+14</A>
+           <b>-1.38</b>
+           <E units="cal/mol">1270.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 NO:1</reactants>
+      <products>HNCO:1 H:1.0</products>
+    </reaction>
+
+    <!-- reaction 0253    -->
+    <reaction reversible="yes" id="0253">
+      <equation>CH2(S) + NO [=] OH + HCN</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.900000E+11</A>
+           <b>-0.69</b>
+           <E units="cal/mol">760.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 NO:1</reactants>
+      <products>HCN:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0254    -->
+    <reaction reversible="yes" id="0254">
+      <equation>CH2(S) + NO [=] H + HCNO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.800000E+10</A>
+           <b>-0.36</b>
+           <E units="cal/mol">580.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 NO:1</reactants>
+      <products>H:1.0 HCNO:1</products>
+    </reaction>
+
+    <!-- reaction 0255    -->
+    <reaction reversible="yes" id="0255">
+      <equation>CH3 + NO [=] HCN + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.600000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">28800.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 NO:1</reactants>
+      <products>H2O:1 HCN:1.0</products>
+    </reaction>
+
+    <!-- reaction 0256    -->
+    <reaction reversible="yes" id="0256">
+      <equation>CH3 + NO [=] H2CN + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">21750.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 NO:1</reactants>
+      <products>H2CN:1.0 OH:1</products>
+    </reaction>
+
+    <!-- reaction 0257    -->
+    <reaction reversible="yes" id="0257">
+      <equation>HCNN + O [=] CO + H + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.200000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 HCNN:1.0</reactants>
+      <products>H:1 N2:1 CO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0258    -->
+    <reaction reversible="yes" id="0258">
+      <equation>HCNN + O [=] HCN + NO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 HCNN:1.0</reactants>
+      <products>HCN:1.0 NO:1</products>
+    </reaction>
+
+    <!-- reaction 0259    -->
+    <reaction reversible="yes" id="0259">
+      <equation>HCNN + O2 [=] O + HCO + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.200000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O2:1 HCNN:1.0</reactants>
+      <products>N2:1 HCO:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0260    -->
+    <reaction reversible="yes" id="0260">
+      <equation>HCNN + OH [=] H + HCO + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.200000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>OH:1 HCNN:1.0</reactants>
+      <products>H:1.0 N2:1 HCO:1</products>
+    </reaction>
+
+    <!-- reaction 0261    -->
+    <reaction reversible="yes" id="0261">
+      <equation>HCNN + H [=] CH2 + N2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 HCNN:1.0</reactants>
+      <products>CH2:1.0 N2:1</products>
+    </reaction>
+
+    <!-- reaction 0262    -->
+    <reaction reversible="yes" id="0262">
+      <equation>HNCO + O [=] NH + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.800000E+04</A>
+           <b>1.41</b>
+           <E units="cal/mol">8500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HNCO:1.0 O:1</reactants>
+      <products>NH:1.0 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0263    -->
+    <reaction reversible="yes" id="0263">
+      <equation>HNCO + O [=] HNO + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+05</A>
+           <b>1.57</b>
+           <E units="cal/mol">44000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HNCO:1.0 O:1</reactants>
+      <products>CO:1 HNO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0264    -->
+    <reaction reversible="yes" id="0264">
+      <equation>HNCO + O [=] NCO + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.200000E+03</A>
+           <b>2.11</b>
+           <E units="cal/mol">11400.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HNCO:1.0 O:1</reactants>
+      <products>OH:1 NCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0265    -->
+    <reaction reversible="yes" id="0265">
+      <equation>HNCO + H [=] NH2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.250000E+04</A>
+           <b>1.7</b>
+           <E units="cal/mol">3800.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HNCO:1.0 H:1</reactants>
+      <products>CO:1 NH2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0266    -->
+    <reaction reversible="yes" id="0266">
+      <equation>HNCO + H [=] H2 + NCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.050000E+02</A>
+           <b>2.5</b>
+           <E units="cal/mol">13300.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HNCO:1.0 H:1</reactants>
+      <products>H2:1.0 NCO:1</products>
+    </reaction>
+
+    <!-- reaction 0267    -->
+    <reaction reversible="yes" id="0267">
+      <equation>HNCO + OH [=] NCO + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.300000E+04</A>
+           <b>1.5</b>
+           <E units="cal/mol">3600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HNCO:1.0 OH:1</reactants>
+      <products>H2O:1 NCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0268    -->
+    <reaction reversible="yes" id="0268">
+      <equation>HNCO + OH [=] NH2 + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.300000E+03</A>
+           <b>1.5</b>
+           <E units="cal/mol">3600.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HNCO:1.0 OH:1</reactants>
+      <products>CO2:1 NH2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0269    -->
+    <reaction reversible="yes" type="threeBody" id="0269">
+      <equation>HNCO + M [=] NH + CO + M</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.180000E+13</A>
+           <b>0</b>
+           <E units="cal/mol">84720.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+      </rateCoeff>
+      <reactants>HNCO:1.0</reactants>
+      <products>NH:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0270    -->
+    <reaction reversible="yes" id="0270">
+      <equation>HCNO + H [=] H + HNCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.100000E+12</A>
+           <b>-0.69</b>
+           <E units="cal/mol">2850.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 HCNO:1.0</reactants>
+      <products>HNCO:1 H:1.0</products>
+    </reaction>
+
+    <!-- reaction 0271    -->
+    <reaction reversible="yes" id="0271">
+      <equation>HCNO + H [=] OH + HCN</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.700000E+08</A>
+           <b>0.18</b>
+           <E units="cal/mol">2120.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 HCNO:1.0</reactants>
+      <products>HCN:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0272    -->
+    <reaction reversible="yes" id="0272">
+      <equation>HCNO + H [=] NH2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.700000E+11</A>
+           <b>-0.75</b>
+           <E units="cal/mol">2890.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 HCNO:1.0</reactants>
+      <products>CO:1 NH2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0273    -->
+    <reaction reversible="yes" id="0273">
+      <equation>HOCN + H [=] H + HNCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+04</A>
+           <b>2</b>
+           <E units="cal/mol">2000.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HOCN:1.0 H:1</reactants>
+      <products>HNCO:1 H:1.0</products>
+    </reaction>
+
+    <!-- reaction 0274    -->
+    <reaction reversible="yes" id="0274">
+      <equation>HCCO + NO [=] HCNO + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HCCO:1.0 NO:1</reactants>
+      <products>CO:1 HCNO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0275    -->
+    <reaction reversible="yes" id="0275">
+      <equation>CH3 + N [=] H2CN + H</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.100000E+11</A>
+           <b>-0.31</b>
+           <E units="cal/mol">290.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 N:1</reactants>
+      <products>H:1 H2CN:1.0</products>
+    </reaction>
+
+    <!-- reaction 0276    -->
+    <reaction reversible="yes" id="0276">
+      <equation>CH3 + N [=] HCN + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.700000E+09</A>
+           <b>0.15</b>
+           <E units="cal/mol">-90.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 N:1</reactants>
+      <products>H2:1 HCN:1.0</products>
+    </reaction>
+
+    <!-- reaction 0277    -->
+    <reaction reversible="yes" id="0277">
+      <equation>NH3 + H [=] NH2 + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.400000E+02</A>
+           <b>2.4</b>
+           <E units="cal/mol">9915.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1 NH3:1.0</reactants>
+      <products>H2:1 NH2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0278    -->
+    <reaction reversible="yes" id="0278">
+      <equation>NH3 + OH [=] NH2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+04</A>
+           <b>1.6</b>
+           <E units="cal/mol">955.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH3:1.0 OH:1</reactants>
+      <products>H2O:1 NH2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0279    -->
+    <reaction reversible="yes" id="0279">
+      <equation>NH3 + O [=] NH2 + OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.400000E+03</A>
+           <b>1.94</b>
+           <E units="cal/mol">6460.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>O:1 NH3:1.0</reactants>
+      <products>OH:1 NH2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0280    -->
+    <reaction reversible="yes" id="0280">
+      <equation>NH + CO2 [=] HNO + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.000000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">14350.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NH:1.0 CO2:1</reactants>
+      <products>CO:1 HNO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0281    -->
+    <reaction reversible="yes" id="0281">
+      <equation>CN + NO2 [=] NCO + NO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.160000E+12</A>
+           <b>-0.752</b>
+           <E units="cal/mol">345.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CN:1.0 NO2:1</reactants>
+      <products>NO:1 NCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0282    -->
+    <reaction reversible="yes" id="0282">
+      <equation>NCO + NO2 [=] N2O + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.250000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">-705.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>NO2:1 NCO:1.0</reactants>
+      <products>CO2:1 N2O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0283    -->
+    <reaction reversible="yes" id="0283">
+      <equation>N + CO2 [=] NO + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.000000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">11300.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CO2:1 N:1.0</reactants>
+      <products>CO:1 NO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0284    -->
+    <reaction reversible="no" id="0284">
+      <equation>O + CH3 =] H + H2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.370000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 O:1.0</reactants>
+      <products>H2:1 H:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0285    -->
+    <reaction reversible="yes" id="0285">
+      <equation>O + C2H4 [=] H + CH2CHO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.700000E+03</A>
+           <b>1.83</b>
+           <E units="cal/mol">220.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H4:1 O:1.0</reactants>
+      <products>H:1.0 CH2CHO:1</products>
+    </reaction>
+
+    <!-- reaction 0286    -->
+    <reaction reversible="yes" id="0286">
+      <equation>O + C2H5 [=] H + CH3CHO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.096000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H5:1 O:1.0</reactants>
+      <products>H:1.0 CH3CHO:1</products>
+    </reaction>
+
+    <!-- reaction 0287    -->
+    <reaction duplicate="yes" reversible="yes" id="0287">
+      <equation>OH + HO2 [=] O2 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.000000E+12</A>
+           <b>0</b>
+           <E units="cal/mol">17330.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>HO2:1 OH:1.0</reactants>
+      <products>H2O:1 O2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0288    -->
+    <reaction reversible="no" id="0288">
+      <equation>OH + CH3 =] H2 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>8.000000E+06</A>
+           <b>0.5</b>
+           <E units="cal/mol">-1755.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1 OH:1.0</reactants>
+      <products>H2:1.0 CH2O:1</products>
+    </reaction>
+
+    <!-- reaction 0289    -->
+    <reaction reversible="yes" type="falloff" id="0289">
+      <equation>CH + H2 (+ M) [=] CH3 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.970000E+09</A>
+           <b>0.43</b>
+           <E units="cal/mol">-370.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>4.820000E+19</A>
+           <b>-2.8</b>
+           <E units="cal/mol">590.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.578 122 2535 9365 </falloff>
+      </rateCoeff>
+      <reactants>H2:1 CH:1.0</reactants>
+      <products>CH3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0290    -->
+    <reaction reversible="no" id="0290">
+      <equation>CH2 + O2 =] 2 H + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.800000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">1500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 O2:1</reactants>
+      <products>H:2.0 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0291    -->
+    <reaction reversible="yes" id="0291">
+      <equation>CH2 + O2 [=] O + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.400000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">1500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:1.0 O2:1</reactants>
+      <products>CH2O:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0292    -->
+    <reaction reversible="no" id="0292">
+      <equation>CH2 + CH2 =] 2 H + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.000000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">10989.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2:2.0</reactants>
+      <products>H:2.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0293    -->
+    <reaction reversible="no" id="0293">
+      <equation>CH2(S) + H2O =] H2 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>6.820000E+07</A>
+           <b>0.25</b>
+           <E units="cal/mol">-935.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2(S):1.0 H2O:1</reactants>
+      <products>H2:1.0 CH2O:1</products>
+    </reaction>
+
+    <!-- reaction 0294    -->
+    <reaction reversible="yes" id="0294">
+      <equation>C2H3 + O2 [=] O + CH2CHO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.030000E+08</A>
+           <b>0.29</b>
+           <E units="cal/mol">11.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H3:1.0 O2:1</reactants>
+      <products>CH2CHO:1 O:1.0</products>
+    </reaction>
+
+    <!-- reaction 0295    -->
+    <reaction reversible="yes" id="0295">
+      <equation>C2H3 + O2 [=] HO2 + C2H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.337000E+03</A>
+           <b>1.61</b>
+           <E units="cal/mol">-384.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C2H3:1.0 O2:1</reactants>
+      <products>HO2:1.0 C2H2:1</products>
+    </reaction>
+
+    <!-- reaction 0296    -->
+    <reaction reversible="yes" id="0296">
+      <equation>O + CH3CHO [=] OH + CH2CHO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.840000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">1808.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3CHO:1 O:1.0</reactants>
+      <products>CH2CHO:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0297    -->
+    <reaction reversible="no" id="0297">
+      <equation>O + CH3CHO =] OH + CH3 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>5.840000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">1808.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3CHO:1 O:1.0</reactants>
+      <products>CH3:1 CO:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0298    -->
+    <reaction reversible="no" id="0298">
+      <equation>O2 + CH3CHO =] HO2 + CH3 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.010000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">39150.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3CHO:1 O2:1.0</reactants>
+      <products>CO:1 CH3:1 HO2:1.0</products>
+    </reaction>
+
+    <!-- reaction 0299    -->
+    <reaction reversible="yes" id="0299">
+      <equation>H + CH3CHO [=] CH2CHO + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.050000E+06</A>
+           <b>1.16</b>
+           <E units="cal/mol">2405.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH3CHO:1</reactants>
+      <products>H2:1 CH2CHO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0300    -->
+    <reaction reversible="no" id="0300">
+      <equation>H + CH3CHO =] CH3 + H2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.050000E+06</A>
+           <b>1.16</b>
+           <E units="cal/mol">2405.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH3CHO:1</reactants>
+      <products>H2:1 CH3:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0301    -->
+    <reaction reversible="no" id="0301">
+      <equation>OH + CH3CHO =] CH3 + H2O + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.343000E+07</A>
+           <b>0.73</b>
+           <E units="cal/mol">-1113.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3CHO:1 OH:1.0</reactants>
+      <products>H2O:1 CH3:1.0 CO:1</products>
+    </reaction>
+
+    <!-- reaction 0302    -->
+    <reaction reversible="no" id="0302">
+      <equation>HO2 + CH3CHO =] CH3 + H2O2 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.010000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">11923.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3CHO:1 HO2:1.0</reactants>
+      <products>CH3:1.0 CO:1 H2O2:1</products>
+    </reaction>
+
+    <!-- reaction 0303    -->
+    <reaction reversible="no" id="0303">
+      <equation>CH3 + CH3CHO =] CH3 + CH4 + CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.720000E+03</A>
+           <b>1.77</b>
+           <E units="cal/mol">5920.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3CHO:1 CH3:1.0</reactants>
+      <products>CO:1 CH3:1.0 CH4:1</products>
+    </reaction>
+
+    <!-- reaction 0304    -->
+    <reaction reversible="yes" type="falloff" id="0304">
+      <equation>H + CH2CO (+ M) [=] CH2CHO (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.865000E+08</A>
+           <b>0.422</b>
+           <E units="cal/mol">-1755.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>1.012000E+36</A>
+           <b>-7.63</b>
+           <E units="cal/mol">3854.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.465 201 1773 5333 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 CH2CO:1</reactants>
+      <products>CH2CHO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0305    -->
+    <reaction reversible="no" id="0305">
+      <equation>O + CH2CHO =] H + CH2 + CO2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.500000E+11</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2CHO:1 O:1.0</reactants>
+      <products>H:1.0 CH2:1 CO2:1</products>
+    </reaction>
+
+    <!-- reaction 0306    -->
+    <reaction reversible="no" id="0306">
+      <equation>O2 + CH2CHO =] OH + CO + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.810000E+07</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2CHO:1 O2:1.0</reactants>
+      <products>CH2O:1 CO:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0307    -->
+    <reaction reversible="no" id="0307">
+      <equation>O2 + CH2CHO =] OH + 2 HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.350000E+07</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2CHO:1 O2:1.0</reactants>
+      <products>HCO:2.0 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0308    -->
+    <reaction reversible="yes" id="0308">
+      <equation>H + CH2CHO [=] CH3 + HCO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.200000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH2CHO:1</reactants>
+      <products>CH3:1.0 HCO:1</products>
+    </reaction>
+
+    <!-- reaction 0309    -->
+    <reaction reversible="yes" id="0309">
+      <equation>H + CH2CHO [=] CH2CO + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.100000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 CH2CHO:1</reactants>
+      <products>H2:1 CH2CO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0310    -->
+    <reaction reversible="yes" id="0310">
+      <equation>OH + CH2CHO [=] H2O + CH2CO</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.200000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2CHO:1 OH:1.0</reactants>
+      <products>H2O:1.0 CH2CO:1</products>
+    </reaction>
+
+    <!-- reaction 0311    -->
+    <reaction reversible="yes" id="0311">
+      <equation>OH + CH2CHO [=] HCO + CH2OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.010000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH2CHO:1 OH:1.0</reactants>
+      <products>CH2OH:1 HCO:1.0</products>
+    </reaction>
+
+    <!-- reaction 0312    -->
+    <reaction reversible="yes" type="falloff" id="0312">
+      <equation>CH3 + C2H5 (+ M) [=] C3H8 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.430000E+09</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>2.710000E+68</A>
+           <b>-16.82</b>
+           <E units="cal/mol">13065.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.1527 291 2742 7748 </falloff>
+      </rateCoeff>
+      <reactants>C2H5:1 CH3:1.0</reactants>
+      <products>C3H8:1.0</products>
+    </reaction>
+
+    <!-- reaction 0313    -->
+    <reaction reversible="yes" id="0313">
+      <equation>O + C3H8 [=] OH + C3H7</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.930000E+02</A>
+           <b>2.68</b>
+           <E units="cal/mol">3716.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C3H8:1 O:1.0</reactants>
+      <products>C3H7:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0314    -->
+    <reaction reversible="yes" id="0314">
+      <equation>H + C3H8 [=] C3H7 + H2</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.320000E+03</A>
+           <b>2.54</b>
+           <E units="cal/mol">6756.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 C3H8:1</reactants>
+      <products>H2:1 C3H7:1.0</products>
+    </reaction>
+
+    <!-- reaction 0315    -->
+    <reaction reversible="yes" id="0315">
+      <equation>OH + C3H8 [=] C3H7 + H2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.160000E+04</A>
+           <b>1.8</b>
+           <E units="cal/mol">934.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C3H8:1 OH:1.0</reactants>
+      <products>C3H7:1.0 H2O:1</products>
+    </reaction>
+
+    <!-- reaction 0316    -->
+    <reaction reversible="yes" id="0316">
+      <equation>C3H7 + H2O2 [=] HO2 + C3H8</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.780000E-01</A>
+           <b>2.72</b>
+           <E units="cal/mol">1500.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C3H7:1.0 H2O2:1</reactants>
+      <products>HO2:1.0 C3H8:1</products>
+    </reaction>
+
+    <!-- reaction 0317    -->
+    <reaction reversible="yes" id="0317">
+      <equation>CH3 + C3H8 [=] C3H7 + CH4</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.030000E-04</A>
+           <b>3.65</b>
+           <E units="cal/mol">7154.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>CH3:1.0 C3H8:1</reactants>
+      <products>C3H7:1.0 CH4:1</products>
+    </reaction>
+
+    <!-- reaction 0318    -->
+    <reaction reversible="yes" type="falloff" id="0318">
+      <equation>CH3 + C2H4 (+ M) [=] C3H7 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.550000E+03</A>
+           <b>1.6</b>
+           <E units="cal/mol">5700.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>3.000000E+57</A>
+           <b>-14.6</b>
+           <E units="cal/mol">18170.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.1894 277 8748 7891 </falloff>
+      </rateCoeff>
+      <reactants>CH3:1.0 C2H4:1</reactants>
+      <products>C3H7:1.0</products>
+    </reaction>
+
+    <!-- reaction 0319    -->
+    <reaction reversible="yes" id="0319">
+      <equation>O + C3H7 [=] C2H5 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>9.640000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C3H7:1 O:1.0</reactants>
+      <products>CH2O:1 C2H5:1.0</products>
+    </reaction>
+
+    <!-- reaction 0320    -->
+    <reaction reversible="yes" type="falloff" id="0320">
+      <equation>H + C3H7 (+ M) [=] C3H8 (+ M)</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>3.613000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+        <Arrhenius name="k0">
+           <A>4.420000E+55</A>
+           <b>-13.545</b>
+           <E units="cal/mol">11357.000000</E>
+        </Arrhenius>
+        <efficiencies default="1.0">AR:0.7  C2H6:3  CH4:2  CO:1.5  CO2:2  H2:2  H2O:6 </efficiencies>
+        <falloff type="Troe">0.315 369 3285 6667 </falloff>
+      </rateCoeff>
+      <reactants>H:1.0 C3H7:1</reactants>
+      <products>C3H8:1.0</products>
+    </reaction>
+
+    <!-- reaction 0321    -->
+    <reaction reversible="yes" id="0321">
+      <equation>H + C3H7 [=] CH3 + C2H5</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>4.060000E+03</A>
+           <b>2.19</b>
+           <E units="cal/mol">890.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>H:1.0 C3H7:1</reactants>
+      <products>C2H5:1 CH3:1.0</products>
+    </reaction>
+
+    <!-- reaction 0322    -->
+    <reaction reversible="yes" id="0322">
+      <equation>OH + C3H7 [=] C2H5 + CH2OH</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.410000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C3H7:1 OH:1.0</reactants>
+      <products>CH2OH:1 C2H5:1.0</products>
+    </reaction>
+
+    <!-- reaction 0323    -->
+    <reaction reversible="yes" id="0323">
+      <equation>HO2 + C3H7 [=] O2 + C3H8</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.550000E+07</A>
+           <b>0.255</b>
+           <E units="cal/mol">-943.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C3H7:1 HO2:1.0</reactants>
+      <products>O2:1.0 C3H8:1</products>
+    </reaction>
+
+    <!-- reaction 0324    -->
+    <reaction reversible="no" id="0324">
+      <equation>HO2 + C3H7 =] OH + C2H5 + CH2O</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>2.410000E+10</A>
+           <b>0</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C3H7:1 HO2:1.0</reactants>
+      <products>CH2O:1 C2H5:1 OH:1.0</products>
+    </reaction>
+
+    <!-- reaction 0325    -->
+    <reaction reversible="yes" id="0325">
+      <equation>CH3 + C3H7 [=] 2 C2H5</equation>
+      <rateCoeff>
+        <Arrhenius>
+           <A>1.927000E+10</A>
+           <b>-0.32</b>
+           <E units="cal/mol">0.000000</E>
+        </Arrhenius>
+      </rateCoeff>
+      <reactants>C3H7:1 CH3:1.0</reactants>
+      <products>C2H5:2.0</products>
+    </reaction>
+  </reactionData>
+</ctml>

--- a/data/gri30.yaml
+++ b/data/gri30.yaml
@@ -1,0 +1,1871 @@
+generator: ctml2yaml
+cantera-version: 3.1.0
+date: Wed, 02 Jul 2025 14:51:31 +0000
+input-files: [data/gri30.xml]
+
+phases:
+- name: gri30
+  elements: [O, H, C, N, Ar]
+  species: [H2, H, O, O2, OH, H2O, HO2, H2O2, C, CH, CH2, CH2(S), CH3, CH4, CO, 
+      CO2, HCO, CH2O, CH2OH, CH3O, CH3OH, C2H, C2H2, C2H3, C2H4, C2H5, C2H6, 
+      HCCO, CH2CO, HCCOH, N, NH, NH2, NH3, NNH, NO, NO2, N2O, HNO, CN, HCN, H2CN,
+    HCNN, HCNO, HOCN, HNCO, NCO, N2, AR, C3H7, C3H8, CH2CHO, CH3CHO]
+  thermo: ideal-gas
+  kinetics: gas
+  reactions: all
+  state: {T: 300.0 K, P: 1.01325e+05 Pa}
+- name: gri30_mix
+  elements: [O, H, C, N, Ar]
+  species: [H2, H, O, O2, OH, H2O, HO2, H2O2, C, CH, CH2, CH2(S), CH3, CH4, CO, 
+      CO2, HCO, CH2O, CH2OH, CH3O, CH3OH, C2H, C2H2, C2H3, C2H4, C2H5, C2H6, 
+      HCCO, CH2CO, HCCOH, N, NH, NH2, NH3, NNH, NO, NO2, N2O, HNO, CN, HCN, H2CN,
+    HCNN, HCNO, HOCN, HNCO, NCO, N2, AR, C3H7, C3H8, CH2CHO, CH3CHO]
+  thermo: ideal-gas
+  transport: mixture-averaged
+  kinetics: gas
+  reactions: all
+  state: {T: 300.0 K, P: 1.01325e+05 Pa}
+- name: gri30_multi
+  elements: [O, H, C, N, Ar]
+  species: [H2, H, O, O2, OH, H2O, HO2, H2O2, C, CH, CH2, CH2(S), CH3, CH4, CO, 
+      CO2, HCO, CH2O, CH2OH, CH3O, CH3OH, C2H, C2H2, C2H3, C2H4, C2H5, C2H6, 
+      HCCO, CH2CO, HCCOH, N, NH, NH2, NH3, NNH, NO, NO2, N2O, HNO, CN, HCN, H2CN,
+    HCNN, HCNO, HOCN, HNCO, NCO, N2, AR, C3H7, C3H8, CH2CHO, CH3CHO]
+  thermo: ideal-gas
+  transport: multicomponent
+  kinetics: gas
+  reactions: all
+  state: {T: 300.0 K, P: 1.01325e+05 Pa}
+
+species:
+- name: H2
+  composition: {H: 2.0}
+  note: TPIS78
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [2.34433112, 7.98052075e-03, -1.9478151e-05, 2.01572094e-08, 
+        -7.37611761e-12, -917.935173, 0.683010238]
+    - [3.3372792, -4.94024731e-05, 4.99456778e-07, -1.79566394e-10, 
+        2.00255376e-14, -950.158922, -3.20502331]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 38.0
+    diameter: 2.92
+    dipole: 0.0
+    polarizability: 0.79
+    rotational-relaxation: 280.0
+- name: H
+  composition: {H: 1.0}
+  note: L 7/88
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [2.5, 7.05332819e-13, -1.99591964e-15, 2.30081632e-18, -9.27732332e-22, 
+        2.54736599e+04, -0.446682853]
+    - [2.50000001, -2.30842973e-11, 1.61561948e-14, -4.73515235e-18, 
+        4.98197357e-22, 2.54736599e+04, -0.446682914]
+  transport:
+    model: gas
+    geometry: atom
+    well-depth: 145.0
+    diameter: 2.05
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 0.0
+- name: O
+  composition: {O: 1.0}
+  note: L 1/90
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.1682671, -3.27931884e-03, 6.64306396e-06, -6.12806624e-09, 
+        2.11265971e-12, 2.91222592e+04, 2.05193346]
+    - [2.56942078, -8.59741137e-05, 4.19484589e-08, -1.00177799e-11, 
+        1.22833691e-15, 2.92175791e+04, 4.78433864]
+  transport:
+    model: gas
+    geometry: atom
+    well-depth: 80.0
+    diameter: 2.75
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 0.0
+- name: O2
+  composition: {O: 2.0}
+  note: TPIS89
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.78245636, -2.99673416e-03, 9.84730201e-06, -9.68129509e-09, 
+        3.24372837e-12, -1063.94356, 3.65767573]
+    - [3.28253784, 1.48308754e-03, -7.57966669e-07, 2.09470555e-10, 
+        -2.16717794e-14, -1088.45772, 5.45323129]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 107.4
+    diameter: 3.46
+    dipole: 0.0
+    polarizability: 1.6
+    rotational-relaxation: 3.8
+- name: OH
+  composition: {H: 1.0, O: 1.0}
+  note: RUS 78
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.99201543, -2.40131752e-03, 4.61793841e-06, -3.88113333e-09, 
+        1.3641147e-12, 3615.08056, -0.103925458]
+    - [3.09288767, 5.48429716e-04, 1.26505228e-07, -8.79461556e-11, 
+        1.17412376e-14, 3858.657, 4.4766961]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 80.0
+    diameter: 2.75
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 0.0
+- name: H2O
+  composition: {H: 2.0, O: 1.0}
+  note: L 8/89
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [4.19864056, -2.0364341e-03, 6.52040211e-06, -5.48797062e-09, 
+        1.77197817e-12, -3.02937267e+04, -0.849032208]
+    - [3.03399249, 2.17691804e-03, -1.64072518e-07, -9.7041987e-11, 
+        1.68200992e-14, -3.00042971e+04, 4.9667701]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 572.4
+    diameter: 2.6
+    dipole: 1.84
+    polarizability: 0.0
+    rotational-relaxation: 4.0
+- name: HO2
+  composition: {H: 1.0, O: 2.0}
+  note: L 5/89
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [4.30179801, -4.74912051e-03, 2.11582891e-05, -2.42763894e-08, 
+        9.29225124e-12, 294.80804, 3.71666245]
+    - [4.0172109, 2.23982013e-03, -6.3365815e-07, 1.1424637e-10, -1.07908535e-14,
+      111.856713, 3.78510215]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 107.4
+    diameter: 3.46
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: H2O2
+  composition: {H: 2.0, O: 2.0}
+  note: L 7/88
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [4.27611269, -5.42822417e-04, 1.67335701e-05, -2.15770813e-08, 
+        8.62454363e-12, -1.77025821e+04, 3.43505074]
+    - [4.16500285, 4.90831694e-03, -1.90139225e-06, 3.71185986e-10, 
+        -2.87908305e-14, -1.78617877e+04, 2.91615662]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 107.4
+    diameter: 3.46
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 3.8
+- name: C
+  composition: {C: 1.0}
+  note: L11/88
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [2.55423955, -3.21537724e-04, 7.33792245e-07, -7.32234889e-10, 
+        2.66521446e-13, 8.54438832e+04, 4.53130848]
+    - [2.49266888, 4.79889284e-05, -7.2433502e-08, 3.74291029e-11, 
+        -4.87277893e-15, 8.54512953e+04, 4.80150373]
+  transport:
+    model: gas
+    geometry: atom
+    well-depth: 71.4
+    diameter: 3.3
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 0.0
+- name: CH
+  composition: {H: 1.0, C: 1.0}
+  note: TPIS79
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.48981665, 3.23835541e-04, -1.68899065e-06, 3.16217327e-09, 
+        -1.40609067e-12, 7.07972934e+04, 2.08401108]
+    - [2.87846473, 9.70913681e-04, 1.44445655e-07, -1.30687849e-10, 
+        1.76079383e-14, 7.10124364e+04, 5.48497999]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 80.0
+    diameter: 2.75
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 0.0
+- name: CH2
+  composition: {H: 2.0, C: 1.0}
+  note: L S/93
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.76267867, 9.68872143e-04, 2.79489841e-06, -3.85091153e-09, 
+        1.68741719e-12, 4.60040401e+04, 1.56253185]
+    - [2.87410113, 3.65639292e-03, -1.40894597e-06, 2.60179549e-10, 
+        -1.87727567e-14, 4.6263604e+04, 6.17119324]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 144.0
+    diameter: 3.8
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 0.0
+- name: CH2(S)
+  composition: {H: 2.0, C: 1.0}
+  note: L S/93
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [4.19860411, -2.36661419e-03, 8.2329622e-06, -6.68815981e-09, 
+        1.94314737e-12, 5.04968163e+04, -0.769118967]
+    - [2.29203842, 4.65588637e-03, -2.01191947e-06, 4.17906e-10, -3.39716365e-14,
+      5.09259997e+04, 8.62650169]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 144.0
+    diameter: 3.8
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 0.0
+- name: CH3
+  composition: {H: 3.0, C: 1.0}
+  note: L11/89
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.6735904, 2.01095175e-03, 5.73021856e-06, -6.87117425e-09, 
+        2.54385734e-12, 1.64449988e+04, 1.60456433]
+    - [2.28571772, 7.23990037e-03, -2.98714348e-06, 5.95684644e-10, 
+        -4.67154394e-14, 1.67755843e+04, 8.48007179]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 144.0
+    diameter: 3.8
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 0.0
+- name: CH4
+  composition: {H: 4.0, C: 1.0}
+  note: L 8/88
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [5.14987613, -0.0136709788, 4.91800599e-05, -4.84743026e-08, 
+        1.66693956e-11, -1.02466476e+04, -4.64130376]
+    - [0.074851495, 0.0133909467, -5.73285809e-06, 1.22292535e-09, 
+        -1.0181523e-13, -9468.34459, 18.437318]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 141.4
+    diameter: 3.75
+    dipole: 0.0
+    polarizability: 2.6
+    rotational-relaxation: 13.0
+- name: CO
+  composition: {C: 1.0, O: 1.0}
+  note: TPIS79
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.57953347, -6.1035368e-04, 1.01681433e-06, 9.07005884e-10, 
+        -9.04424499e-13, -1.4344086e+04, 3.50840928]
+    - [2.71518561, 2.06252743e-03, -9.98825771e-07, 2.30053008e-10, 
+        -2.03647716e-14, -1.41518724e+04, 7.81868772]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 98.1
+    diameter: 3.65
+    dipole: 0.0
+    polarizability: 1.95
+    rotational-relaxation: 1.8
+- name: CO2
+  composition: {C: 1.0, O: 2.0}
+  note: L 7/88
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [2.35677352, 8.98459677e-03, -7.12356269e-06, 2.45919022e-09, 
+        -1.43699548e-13, -4.83719697e+04, 9.90105222]
+    - [3.85746029, 4.41437026e-03, -2.21481404e-06, 5.23490188e-10, 
+        -4.72084164e-14, -4.8759166e+04, 2.27163806]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 244.0
+    diameter: 3.76
+    dipole: 0.0
+    polarizability: 2.65
+    rotational-relaxation: 2.1
+- name: HCO
+  composition: {H: 1.0, C: 1.0, O: 1.0}
+  note: L12/89
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [4.22118584, -3.24392532e-03, 1.37799446e-05, -1.33144093e-08, 
+        4.33768865e-12, 3839.56496, 3.39437243]
+    - [2.77217438, 4.95695526e-03, -2.48445613e-06, 5.89161778e-10, 
+        -5.33508711e-14, 4011.91815, 9.79834492]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 498.0
+    diameter: 3.59
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 0.0
+- name: CH2O
+  composition: {H: 2.0, C: 1.0, O: 1.0}
+  note: L 8/88
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [4.79372315, -9.90833369e-03, 3.73220008e-05, -3.79285261e-08, 
+        1.31772652e-11, -1.43089567e+04, 0.6028129]
+    - [1.76069008, 9.20000082e-03, -4.42258813e-06, 1.00641212e-09, 
+        -8.8385564e-14, -1.39958323e+04, 13.656323]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 498.0
+    diameter: 3.59
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 2.0
+- name: CH2OH
+  composition: {H: 3.0, C: 1.0, O: 1.0}
+  note: GUNL93
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.86388918, 5.59672304e-03, 5.93271791e-06, -1.04532012e-08, 
+        4.36967278e-12, -3193.91367, 5.47302243]
+    - [3.69266569, 8.64576797e-03, -3.7510112e-06, 7.87234636e-10, 
+        -6.48554201e-14, -3242.50627, 5.81043215]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 417.0
+    diameter: 3.69
+    dipole: 1.7
+    polarizability: 0.0
+    rotational-relaxation: 2.0
+- name: CH3O
+  composition: {H: 3.0, C: 1.0, O: 1.0}
+  note: '121686'
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 3000.0]
+    data:
+    - [2.106204, 7.216595e-03, 5.338472e-06, -7.377636e-09, 2.07561e-12, 
+        978.6011, 13.152177]
+    - [3.770799, 7.871497e-03, -2.656384e-06, 3.944431e-10, -2.112616e-14, 
+        127.83252, 2.929575]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 417.0
+    diameter: 3.69
+    dipole: 1.7
+    polarizability: 0.0
+    rotational-relaxation: 2.0
+- name: CH3OH
+  composition: {H: 4.0, C: 1.0, O: 1.0}
+  note: L 8/88
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [5.71539582, -0.0152309129, 6.52441155e-05, -7.10806889e-08, 
+        2.61352698e-11, -2.56427656e+04, -1.50409823]
+    - [1.78970791, 0.0140938292, -6.36500835e-06, 1.38171085e-09, -1.1706022e-13,
+      -2.53748747e+04, 14.5023623]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 481.8
+    diameter: 3.63
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: C2H
+  composition: {H: 1.0, C: 2.0}
+  note: L 1/91
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [2.88965733, 0.0134099611, -2.84769501e-05, 2.94791045e-08, 
+        -1.09331511e-11, 6.68393932e+04, 6.22296438]
+    - [3.16780652, 4.75221902e-03, -1.83787077e-06, 3.04190252e-10, 
+        -1.7723277e-14, 6.7121065e+04, 6.63589475]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 209.0
+    diameter: 4.1
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 2.5
+- name: C2H2
+  composition: {H: 2.0, C: 2.0}
+  note: L 1/91
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [0.808681094, 0.0233615629, -3.55171815e-05, 2.80152437e-08, 
+        -8.50072974e-12, 2.64289807e+04, 13.9397051]
+    - [4.14756964, 5.96166664e-03, -2.37294852e-06, 4.67412171e-10, 
+        -3.61235213e-14, 2.59359992e+04, -1.23028121]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 209.0
+    diameter: 4.1
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 2.5
+- name: C2H3
+  composition: {H: 3.0, C: 2.0}
+  note: L 2/92
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.21246645, 1.51479162e-03, 2.59209412e-05, -3.57657847e-08, 
+        1.47150873e-11, 3.48598468e+04, 8.51054025]
+    - [3.016724, 0.0103302292, -4.68082349e-06, 1.01763288e-09, -8.62607041e-14, 
+        3.46128739e+04, 7.78732378]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 209.0
+    diameter: 4.1
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: C2H4
+  composition: {H: 4.0, C: 2.0}
+  note: L 1/91
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.95920148, -7.57052247e-03, 5.70990292e-05, -6.91588753e-08, 
+        2.69884373e-11, 5089.77593, 4.09733096]
+    - [2.03611116, 0.0146454151, -6.71077915e-06, 1.47222923e-09, 
+        -1.25706061e-13, 4939.88614, 10.3053693]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 280.8
+    diameter: 3.97
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.5
+- name: C2H5
+  composition: {H: 5.0, C: 2.0}
+  note: L12/92
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [4.30646568, -4.18658892e-03, 4.97142807e-05, -5.99126606e-08, 
+        2.30509004e-11, 1.28416265e+04, 4.70720924]
+    - [1.95465642, 0.0173972722, -7.98206668e-06, 1.75217689e-09, 
+        -1.49641576e-13, 1.285752e+04, 13.4624343]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 252.3
+    diameter: 4.3
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.5
+- name: C2H6
+  composition: {H: 6.0, C: 2.0}
+  note: L 8/88
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [4.29142492, -5.5015427e-03, 5.99438288e-05, -7.08466285e-08, 
+        2.68685771e-11, -1.15222055e+04, 2.66682316]
+    - [1.0718815, 0.0216852677, -1.00256067e-05, 2.21412001e-09, -1.9000289e-13, 
+        -1.14263932e+04, 15.1156107]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 252.3
+    diameter: 4.3
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.5
+- name: HCCO
+  composition: {H: 1.0, C: 2.0, O: 1.0}
+  note: SRIC91
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 4000.0]
+    data:
+    - [2.2517214, 0.017655021, -2.3729101e-05, 1.7275759e-08, -5.0664811e-12, 
+        2.0059449e+04, 12.490417]
+    - [5.6282058, 4.0853401e-03, -1.5934547e-06, 2.8626052e-10, -1.9407832e-14, 
+        1.9327215e+04, -3.9302595]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 150.0
+    diameter: 2.5
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: CH2CO
+  composition: {H: 2.0, C: 2.0, O: 1.0}
+  note: L 5/90
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [2.1358363, 0.0181188721, -1.73947474e-05, 9.34397568e-09, -2.01457615e-12,
+      -7042.91804, 12.215648]
+    - [4.51129732, 9.00359745e-03, -4.16939635e-06, 9.23345882e-10, 
+        -7.94838201e-14, -7551.05311, 0.632247205]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 436.0
+    diameter: 3.97
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 2.0
+- name: HCCOH
+  composition: {H: 2.0, C: 2.0, O: 1.0}
+  note: SRI91
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [1.2423733, 0.031072201, -5.0866864e-05, 4.3137131e-08, -1.4014594e-11, 
+        8031.6143, 13.874319]
+    - [5.9238291, 6.79236e-03, -2.5658564e-06, 4.4987841e-10, -2.9940101e-14, 
+        7264.626, -7.6017742]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 436.0
+    diameter: 3.97
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 2.0
+- name: N
+  composition: {N: 1.0}
+  note: L 6/88
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [2.5, 0.0, 0.0, 0.0, 0.0, 5.6104637e+04, 4.1939087]
+    - [2.4159429, 1.7489065e-04, -1.1902369e-07, 3.0226245e-11, -2.0360982e-15, 
+        5.6133773e+04, 4.6496096]
+  transport:
+    model: gas
+    geometry: atom
+    well-depth: 71.4
+    diameter: 3.3
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 0.0
+- name: NH
+  composition: {H: 1.0, N: 1.0}
+  note: And94
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [3.4929085, 3.1179198e-04, -1.4890484e-06, 2.4816442e-09, -1.0356967e-12, 
+        4.1880629e+04, 1.8483278]
+    - [2.7836928, 1.329843e-03, -4.2478047e-07, 7.8348501e-11, -5.504447e-15, 
+        4.2120848e+04, 5.7407799]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 80.0
+    diameter: 2.65
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 4.0
+- name: NH2
+  composition: {H: 2.0, N: 1.0}
+  note: And89
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [4.2040029, -2.1061385e-03, 7.1068348e-06, -5.6115197e-09, 1.6440717e-12, 
+        2.188591e+04, -0.14184248]
+    - [2.8347421, 3.2073082e-03, -9.3390804e-07, 1.3702953e-10, -7.9206144e-15, 
+        2.2171957e+04, 6.5204163]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 80.0
+    diameter: 2.65
+    dipole: 0.0
+    polarizability: 2.26
+    rotational-relaxation: 4.0
+- name: NH3
+  composition: {H: 3.0, N: 1.0}
+  note: J 6/77
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [4.2860274, -4.660523e-03, 2.1718513e-05, -2.2808887e-08, 8.2638046e-12, 
+        -6741.7285, -0.62537277]
+    - [2.6344521, 5.666256e-03, -1.7278676e-06, 2.3867161e-10, -1.2578786e-14, 
+        -6544.6958, 6.5662928]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 481.0
+    diameter: 2.92
+    dipole: 1.47
+    polarizability: 0.0
+    rotational-relaxation: 10.0
+- name: NNH
+  composition: {H: 1.0, N: 2.0}
+  note: T07/93
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [4.3446927, -4.8497072e-03, 2.0059459e-05, -2.1726464e-08, 7.9469539e-12, 
+        2.8791973e+04, 2.977941]
+    - [3.7667544, 2.8915082e-03, -1.041662e-06, 1.6842594e-10, -1.0091896e-14, 
+        2.8650697e+04, 4.4705067]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 71.4
+    diameter: 3.8
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: NO
+  composition: {O: 1.0, N: 1.0}
+  note: RUS 78
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [4.2184763, -4.638976e-03, 1.1041022e-05, -9.3361354e-09, 2.803577e-12, 
+        9844.623, 2.2808464]
+    - [3.2606056, 1.1911043e-03, -4.2917048e-07, 6.9457669e-11, -4.0336099e-15, 
+        9920.9746, 6.3693027]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 97.53
+    diameter: 3.62
+    dipole: 0.0
+    polarizability: 1.76
+    rotational-relaxation: 4.0
+- name: NO2
+  composition: {O: 2.0, N: 1.0}
+  note: L 7/88
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [3.9440312, -1.585429e-03, 1.6657812e-05, -2.0475426e-08, 7.8350564e-12, 
+        2896.6179, 6.3119917]
+    - [4.8847542, 2.1723956e-03, -8.2806906e-07, 1.574751e-10, -1.0510895e-14, 
+        2316.4983, -0.11741695]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 200.0
+    diameter: 3.5
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: N2O
+  composition: {O: 1.0, N: 2.0}
+  note: L 7/88
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [2.2571502, 0.011304728, -1.3671319e-05, 9.6819806e-09, -2.9307182e-12, 
+        8741.7744, 10.757992]
+    - [4.8230729, 2.6270251e-03, -9.5850874e-07, 1.6000712e-10, -9.7752303e-15, 
+        8073.4048, -2.2017207]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 232.4
+    diameter: 3.83
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: HNO
+  composition: {H: 1.0, O: 1.0, N: 1.0}
+  note: And93
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [4.5334916, -5.6696171e-03, 1.8473207e-05, -1.7137094e-08, 5.5454573e-12, 
+        1.1548297e+04, 1.7498417]
+    - [2.9792509, 3.4944059e-03, -7.8549778e-07, 5.7479594e-11, -1.9335916e-16, 
+        1.1750582e+04, 8.6063728]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 116.7
+    diameter: 3.49
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: CN
+  composition: {C: 1.0, N: 1.0}
+  note: HBH92
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [3.6129351, -9.5551327e-04, 2.1442977e-06, -3.1516323e-10, -4.6430356e-13, 
+        5.170834e+04, 3.9804995]
+    - [3.7459805, 4.3450775e-05, 2.9705984e-07, -6.8651806e-11, 4.4134173e-15, 
+        5.1536188e+04, 2.7867601]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 75.0
+    diameter: 3.86
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: HCN
+  composition: {H: 1.0, C: 1.0, N: 1.0}
+  note: GRI/98
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [2.2589886, 0.01005117, -1.3351763e-05, 1.0092349e-08, -3.0089028e-12, 
+        1.4712633e+04, 8.9164419]
+    - [3.8022392, 3.1464228e-03, -1.0632185e-06, 1.6619757e-10, -9.799757e-15, 
+        1.4407292e+04, 1.5754601]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 569.0
+    diameter: 3.63
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: H2CN
+  composition: {H: 2.0, C: 1.0, N: 1.0}
+  note: '41687'
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 4000.0]
+    data:
+    - [2.851661, 5.6952331e-03, 1.07114e-06, -1.622612e-09, -2.3511081e-13, 
+        2.863782e+04, 8.9927511]
+    - [5.209703, 2.9692911e-03, -2.8555891e-07, -1.63555e-10, 3.0432589e-14, 
+        2.7677109e+04, -4.444478]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 569.0
+    diameter: 3.63
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: HCNN
+  composition: {H: 1.0, C: 1.0, N: 2.0}
+  note: SRI/94
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [2.5243194, 0.015960619, -1.8816354e-05, 1.212554e-08, -3.2357378e-12, 
+        5.4261984e+04, 11.67587]
+    - [5.8946362, 3.9895959e-03, -1.598238e-06, 2.9249395e-10, -2.0094686e-14, 
+        5.3452941e+04, -5.1030502]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 150.0
+    diameter: 2.5
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: HCNO
+  composition: {H: 1.0, C: 1.0, O: 1.0, N: 1.0}
+  note: BDEA94
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1382.0, 5000.0]
+    data:
+    - [2.64727989, 0.0127505342, -1.04794236e-05, 4.41432836e-09, 
+        -7.57521466e-13, 1.92990252e+04, 10.7332972]
+    - [6.59860456, 3.02778626e-03, -1.07704346e-06, 1.71666528e-10, 
+        -1.01439391e-14, 1.79661339e+04, -10.3306599]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 232.4
+    diameter: 3.83
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: HOCN
+  composition: {H: 1.0, C: 1.0, O: 1.0, N: 1.0}
+  note: BDEA94
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1368.0, 5000.0]
+    data:
+    - [3.78604952, 6.88667922e-03, -3.21487864e-06, 5.17195767e-10, 
+        1.19360788e-14, -2826.984, 5.63292162]
+    - [5.89784885, 3.16789393e-03, -1.11801064e-06, 1.77243144e-10, 
+        -1.04339177e-14, -3706.53331, -6.18167825]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 232.4
+    diameter: 3.83
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: HNCO
+  composition: {H: 1.0, C: 1.0, O: 1.0, N: 1.0}
+  note: BDEA94
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1478.0, 5000.0]
+    data:
+    - [3.63096317, 7.30282357e-03, -2.28050003e-06, -6.61271298e-10, 
+        3.62235752e-13, -1.55873636e+04, 6.19457727]
+    - [6.22395134, 3.17864004e-03, -1.09378755e-06, 1.70735163e-10, 
+        -9.95021955e-15, -1.66599344e+04, -8.38224741]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 232.4
+    diameter: 3.83
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: NCO
+  composition: {C: 1.0, O: 1.0, N: 1.0}
+  note: EA 93
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [2.8269308, 8.8051688e-03, -8.3866134e-06, 4.8016964e-09, -1.3313595e-12, 
+        1.4682477e+04, 9.5504646]
+    - [5.1521845, 2.3051761e-03, -8.8033153e-07, 1.4789098e-10, -9.0977996e-15, 
+        1.4004123e+04, -2.544266]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 232.4
+    diameter: 3.83
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: N2
+  composition: {N: 2.0}
+  note: '121286'
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [3.298677, 1.4082404e-03, -3.963222e-06, 5.641515e-09, -2.444854e-12, 
+        -1020.8999, 3.950372]
+    - [2.92664, 1.4879768e-03, -5.68476e-07, 1.0097038e-10, -6.753351e-15, 
+        -922.7977, 5.980528]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 97.53
+    diameter: 3.62
+    dipole: 0.0
+    polarizability: 1.76
+    rotational-relaxation: 4.0
+- name: AR
+  composition: {Ar: 1.0}
+  note: '120186'
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [2.5, 0.0, 0.0, 0.0, 0.0, -745.375, 4.366]
+    - [2.5, 0.0, 0.0, 0.0, 0.0, -745.375, 4.366]
+  transport:
+    model: gas
+    geometry: atom
+    well-depth: 136.5
+    diameter: 3.33
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 0.0
+- name: C3H7
+  composition: {H: 7.0, C: 3.0}
+  note: L 9/84
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [1.0515518, 0.02599198, 2.380054e-06, -1.9609569e-08, 9.373247e-12, 
+        1.0631863e+04, 21.122559]
+    - [7.7026987, 0.016044203, -5.283322e-06, 7.629859e-10, -3.9392284e-14, 
+        8298.4336, -15.48018]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 266.8
+    diameter: 4.98
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: C3H8
+  composition: {H: 8.0, C: 3.0}
+  note: L 4/85
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [0.93355381, 0.026424579, 6.1059727e-06, -2.1977499e-08, 9.5149253e-12, 
+        -1.395852e+04, 19.201691]
+    - [7.5341368, 0.018872239, -6.2718491e-06, 9.1475649e-10, -4.7838069e-14, 
+        -1.6467516e+04, -17.892349]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 266.8
+    diameter: 4.98
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 1.0
+- name: CH2CHO
+  composition: {H: 3.0, C: 2.0, O: 1.0}
+  note: SAND86
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [3.409062, 0.010738574, 1.891492e-06, -7.158583e-09, 2.867385e-12, 
+        1521.4766, 9.55829]
+    - [5.97567, 8.130591e-03, -2.743624e-06, 4.070304e-10, -2.176017e-14, 
+        490.3218, -5.045251]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 436.0
+    diameter: 3.97
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 2.0
+- name: CH3CHO
+  composition: {H: 4.0, C: 2.0, O: 1.0}
+  note: L 8/88
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [4.7294595, -3.1932858e-03, 4.7534921e-05, -5.7458611e-08, 2.1931112e-11, 
+        -2.1572878e+04, 4.1030159]
+    - [5.4041108, 0.011723059, -4.2263137e-06, 6.8372451e-10, -4.0984863e-14, 
+        -2.2593122e+04, -3.4807917]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 436.0
+    diameter: 3.97
+    dipole: 0.0
+    polarizability: 0.0
+    rotational-relaxation: 2.0
+
+reactions:
+- equation: 2 O + M <=> O2 + M
+  type: three-body
+  rate-constant: {A: 1.2e+11, b: -1.0, Ea: 0.0 cal/mol}
+  efficiencies: {AR: 0.83, C2H6: 3.0, CH4: 2.0, CO: 1.75, CO2: 3.6, H2: 2.4, H2O: 
+      15.4}
+- equation: O + H + M <=> OH + M
+  type: three-body
+  rate-constant: {A: 5.0e+11, b: -1.0, Ea: 0.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+- equation: O + H2 <=> H + OH
+  rate-constant: {A: 38.7, b: 2.7, Ea: 6260.0 cal/mol}
+- equation: O + HO2 <=> OH + O2
+  rate-constant: {A: 2.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O + H2O2 <=> OH + HO2
+  rate-constant: {A: 9630.0, b: 2.0, Ea: 4000.0 cal/mol}
+- equation: O + CH <=> H + CO
+  rate-constant: {A: 5.7e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O + CH2 <=> H + HCO
+  rate-constant: {A: 8.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O + CH2(S) <=> H2 + CO
+  rate-constant: {A: 1.5e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O + CH2(S) <=> H + HCO
+  rate-constant: {A: 1.5e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O + CH3 <=> H + CH2O
+  rate-constant: {A: 5.06e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O + CH4 <=> OH + CH3
+  rate-constant: {A: 1.02e+06, b: 1.5, Ea: 8600.0 cal/mol}
+- equation: O + CO (+ M) <=> CO2 (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 1.8e+07, b: 0.0, Ea: 2385.0 cal/mol}
+  low-P-rate-constant: {A: 6.02e+08, b: 0.0, Ea: 3000.0 cal/mol}
+  efficiencies: {AR: 0.5, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 3.5, H2: 2.0, H2O: 
+      6.0, O2: 6.0}
+- equation: O + HCO <=> OH + CO
+  rate-constant: {A: 3.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O + HCO <=> H + CO2
+  rate-constant: {A: 3.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O + CH2O <=> OH + HCO
+  rate-constant: {A: 3.9e+10, b: 0.0, Ea: 3540.0 cal/mol}
+- equation: O + CH2OH <=> OH + CH2O
+  rate-constant: {A: 1.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O + CH3O <=> OH + CH2O
+  rate-constant: {A: 1.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O + CH3OH <=> OH + CH2OH
+  rate-constant: {A: 388.0, b: 2.5, Ea: 3100.0 cal/mol}
+- equation: O + CH3OH <=> OH + CH3O
+  rate-constant: {A: 130.0, b: 2.5, Ea: 5000.0 cal/mol}
+- equation: O + C2H <=> CH + CO
+  rate-constant: {A: 5.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O + C2H2 <=> H + HCCO
+  rate-constant: {A: 1.35e+04, b: 2.0, Ea: 1900.0 cal/mol}
+- equation: O + C2H2 <=> OH + C2H
+  rate-constant: {A: 4.6e+16, b: -1.41, Ea: 2.895e+04 cal/mol}
+- equation: O + C2H2 <=> CO + CH2
+  rate-constant: {A: 6940.0, b: 2.0, Ea: 1900.0 cal/mol}
+- equation: O + C2H3 <=> H + CH2CO
+  rate-constant: {A: 3.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O + C2H4 <=> CH3 + HCO
+  rate-constant: {A: 1.25e+04, b: 1.83, Ea: 220.0 cal/mol}
+- equation: O + C2H5 <=> CH3 + CH2O
+  rate-constant: {A: 2.24e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O + C2H6 <=> OH + C2H5
+  rate-constant: {A: 8.98e+04, b: 1.92, Ea: 5690.0 cal/mol}
+- equation: O + HCCO <=> H + 2 CO
+  rate-constant: {A: 1.0e+11, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O + CH2CO <=> OH + HCCO
+  rate-constant: {A: 1.0e+10, b: 0.0, Ea: 8000.0 cal/mol}
+- equation: O + CH2CO <=> CH2 + CO2
+  rate-constant: {A: 1.75e+09, b: 0.0, Ea: 1350.0 cal/mol}
+- equation: O2 + CO <=> O + CO2
+  rate-constant: {A: 2.5e+09, b: 0.0, Ea: 4.78e+04 cal/mol}
+- equation: O2 + CH2O <=> HO2 + HCO
+  rate-constant: {A: 1.0e+11, b: 0.0, Ea: 4.0e+04 cal/mol}
+- equation: H + O2 + M <=> HO2 + M
+  type: three-body
+  rate-constant: {A: 2.8e+12, b: -0.86, Ea: 0.0 cal/mol}
+  efficiencies: {AR: 0.0, C2H6: 1.5, CO: 0.75, CO2: 1.5, H2O: 0.0, N2: 0.0, O2: 
+      0.0}
+- equation: H + 2 O2 <=> HO2 + O2
+  rate-constant: {A: 2.08e+13, b: -1.24, Ea: 0.0 cal/mol}
+- equation: H + O2 + H2O <=> HO2 + H2O
+  rate-constant: {A: 1.126e+13, b: -0.76, Ea: 0.0 cal/mol}
+- equation: H + O2 + N2 <=> HO2 + N2
+  rate-constant: {A: 2.6e+13, b: -1.24, Ea: 0.0 cal/mol}
+- equation: H + O2 + AR <=> HO2 + AR
+  rate-constant: {A: 7.0e+11, b: -0.8, Ea: 0.0 cal/mol}
+- equation: H + O2 <=> O + OH
+  rate-constant: {A: 2.65e+13, b: -0.6707, Ea: 1.7041e+04 cal/mol}
+- equation: 2 H + M <=> H2 + M
+  type: three-body
+  rate-constant: {A: 1.0e+12, b: -1.0, Ea: 0.0 cal/mol}
+  efficiencies: {AR: 0.63, C2H6: 3.0, CH4: 2.0, CO2: 0.0, H2: 0.0, H2O: 0.0}
+- equation: 2 H + H2 <=> 2 H2
+  rate-constant: {A: 9.0e+10, b: -0.6, Ea: 0.0 cal/mol}
+- equation: 2 H + H2O <=> H2 + H2O
+  rate-constant: {A: 6.0e+13, b: -1.25, Ea: 0.0 cal/mol}
+- equation: 2 H + CO2 <=> H2 + CO2
+  rate-constant: {A: 5.5e+14, b: -2.0, Ea: 0.0 cal/mol}
+- equation: H + OH + M <=> H2O + M
+  type: three-body
+  rate-constant: {A: 2.2e+16, b: -2.0, Ea: 0.0 cal/mol}
+  efficiencies: {AR: 0.38, C2H6: 3.0, CH4: 2.0, H2: 0.73, H2O: 3.65}
+- equation: H + HO2 <=> O + H2O
+  rate-constant: {A: 3.97e+09, b: 0.0, Ea: 671.0 cal/mol}
+- equation: H + HO2 <=> O2 + H2
+  rate-constant: {A: 4.48e+10, b: 0.0, Ea: 1068.0 cal/mol}
+- equation: H + HO2 <=> 2 OH
+  rate-constant: {A: 8.4e+10, b: 0.0, Ea: 635.0 cal/mol}
+- equation: H + H2O2 <=> HO2 + H2
+  rate-constant: {A: 1.21e+04, b: 2.0, Ea: 5200.0 cal/mol}
+- equation: H + H2O2 <=> OH + H2O
+  rate-constant: {A: 1.0e+10, b: 0.0, Ea: 3600.0 cal/mol}
+- equation: H + CH <=> C + H2
+  rate-constant: {A: 1.65e+11, b: 0.0, Ea: 0.0 cal/mol}
+- equation: H + CH2 (+ M) <=> CH3 (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 6.0e+11, b: 0.0, Ea: 0.0 cal/mol}
+  low-P-rate-constant: {A: 1.04e+20, b: -2.76, Ea: 1600.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.562, T3: 91.0, T1: 5836.0, T2: 8552.0}
+- equation: H + CH2(S) <=> CH + H2
+  rate-constant: {A: 3.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: H + CH3 (+ M) <=> CH4 (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 1.39e+13, b: -0.534, Ea: 536.0 cal/mol}
+  low-P-rate-constant: {A: 2.62e+27, b: -4.76, Ea: 2440.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 3.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.783, T3: 74.0, T1: 2941.0, T2: 6964.0}
+- equation: H + CH4 <=> CH3 + H2
+  rate-constant: {A: 6.6e+05, b: 1.62, Ea: 1.084e+04 cal/mol}
+- equation: H + HCO (+ M) <=> CH2O (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 1.09e+09, b: 0.48, Ea: -260.0 cal/mol}
+  low-P-rate-constant: {A: 2.47e+18, b: -2.57, Ea: 425.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.7824, T3: 271.0, T1: 2755.0, T2: 6570.0}
+- equation: H + HCO <=> H2 + CO
+  rate-constant: {A: 7.34e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: H + CH2O (+ M) <=> CH2OH (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 5.4e+08, b: 0.454, Ea: 3600.0 cal/mol}
+  low-P-rate-constant: {A: 1.27e+26, b: -4.82, Ea: 6530.0 cal/mol}
+  efficiencies: {C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 6.0}
+  Troe: {A: 0.7187, T3: 103.0, T1: 1291.0, T2: 4160.0}
+- equation: H + CH2O (+ M) <=> CH3O (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 5.4e+08, b: 0.454, Ea: 2600.0 cal/mol}
+  low-P-rate-constant: {A: 2.2e+24, b: -4.8, Ea: 5560.0 cal/mol}
+  efficiencies: {C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 6.0}
+  Troe: {A: 0.758, T3: 94.0, T1: 1555.0, T2: 4200.0}
+- equation: H + CH2O <=> HCO + H2
+  rate-constant: {A: 5.74e+04, b: 1.9, Ea: 2742.0 cal/mol}
+- equation: H + CH2OH (+ M) <=> CH3OH (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 1.055e+09, b: 0.5, Ea: 86.0 cal/mol}
+  low-P-rate-constant: {A: 4.36e+25, b: -4.65, Ea: 5080.0 cal/mol}
+  efficiencies: {C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 6.0}
+  Troe: {A: 0.6, T3: 100.0, T1: 9.0e+04, T2: 1.0e+04}
+- equation: H + CH2OH <=> H2 + CH2O
+  rate-constant: {A: 2.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: H + CH2OH <=> OH + CH3
+  rate-constant: {A: 1.65e+08, b: 0.65, Ea: -284.0 cal/mol}
+- equation: H + CH2OH <=> CH2(S) + H2O
+  rate-constant: {A: 3.28e+10, b: -0.09, Ea: 610.0 cal/mol}
+- equation: H + CH3O (+ M) <=> CH3OH (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 2.43e+09, b: 0.515, Ea: 50.0 cal/mol}
+  low-P-rate-constant: {A: 4.66e+35, b: -7.44, Ea: 1.408e+04 cal/mol}
+  efficiencies: {C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 6.0}
+  Troe: {A: 0.7, T3: 100.0, T1: 9.0e+04, T2: 1.0e+04}
+- equation: H + CH3O <=> H + CH2OH
+  rate-constant: {A: 4.15e+04, b: 1.63, Ea: 1924.0 cal/mol}
+- equation: H + CH3O <=> H2 + CH2O
+  rate-constant: {A: 2.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: H + CH3O <=> OH + CH3
+  rate-constant: {A: 1.5e+09, b: 0.5, Ea: -110.0 cal/mol}
+- equation: H + CH3O <=> CH2(S) + H2O
+  rate-constant: {A: 2.62e+11, b: -0.23, Ea: 1070.0 cal/mol}
+- equation: H + CH3OH <=> CH2OH + H2
+  rate-constant: {A: 1.7e+04, b: 2.1, Ea: 4870.0 cal/mol}
+- equation: H + CH3OH <=> CH3O + H2
+  rate-constant: {A: 4200.0, b: 2.1, Ea: 4870.0 cal/mol}
+- equation: H + C2H (+ M) <=> C2H2 (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 1.0e+14, b: -1.0, Ea: 0.0 cal/mol}
+  low-P-rate-constant: {A: 3.75e+27, b: -4.8, Ea: 1900.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.6464, T3: 132.0, T1: 1315.0, T2: 5566.0}
+- equation: H + C2H2 (+ M) <=> C2H3 (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 5.6e+09, b: 0.0, Ea: 2400.0 cal/mol}
+  low-P-rate-constant: {A: 3.8e+34, b: -7.27, Ea: 7220.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.7507, T3: 98.5, T1: 1302.0, T2: 4167.0}
+- equation: H + C2H3 (+ M) <=> C2H4 (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 6.08e+09, b: 0.27, Ea: 280.0 cal/mol}
+  low-P-rate-constant: {A: 1.4e+24, b: -3.86, Ea: 3320.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.782, T3: 207.5, T1: 2663.0, T2: 6095.0}
+- equation: H + C2H3 <=> H2 + C2H2
+  rate-constant: {A: 3.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: H + C2H4 (+ M) <=> C2H5 (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 5.4e+08, b: 0.454, Ea: 1820.0 cal/mol}
+  low-P-rate-constant: {A: 6.0e+35, b: -7.62, Ea: 6970.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.9753, T3: 210.0, T1: 984.0, T2: 4374.0}
+- equation: H + C2H4 <=> C2H3 + H2
+  rate-constant: {A: 1325.0, b: 2.53, Ea: 1.224e+04 cal/mol}
+- equation: H + C2H5 (+ M) <=> C2H6 (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 5.21e+14, b: -0.99, Ea: 1580.0 cal/mol}
+  low-P-rate-constant: {A: 1.99e+35, b: -7.08, Ea: 6685.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.8422, T3: 125.0, T1: 2219.0, T2: 6882.0}
+- equation: H + C2H5 <=> H2 + C2H4
+  rate-constant: {A: 2.0e+09, b: 0.0, Ea: 0.0 cal/mol}
+- equation: H + C2H6 <=> C2H5 + H2
+  rate-constant: {A: 1.15e+05, b: 1.9, Ea: 7530.0 cal/mol}
+- equation: H + HCCO <=> CH2(S) + CO
+  rate-constant: {A: 1.0e+11, b: 0.0, Ea: 0.0 cal/mol}
+- equation: H + CH2CO <=> HCCO + H2
+  rate-constant: {A: 5.0e+10, b: 0.0, Ea: 8000.0 cal/mol}
+- equation: H + CH2CO <=> CH3 + CO
+  rate-constant: {A: 1.13e+10, b: 0.0, Ea: 3428.0 cal/mol}
+- equation: H + HCCOH <=> H + CH2CO
+  rate-constant: {A: 1.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: H2 + CO (+ M) <=> CH2O (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 4.3e+04, b: 1.5, Ea: 7.96e+04 cal/mol}
+  low-P-rate-constant: {A: 5.07e+21, b: -3.42, Ea: 8.435e+04 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.932, T3: 197.0, T1: 1540.0, T2: 1.03e+04}
+- equation: OH + H2 <=> H + H2O
+  rate-constant: {A: 2.16e+05, b: 1.51, Ea: 3430.0 cal/mol}
+- equation: 2 OH (+ M) <=> H2O2 (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 7.4e+10, b: -0.37, Ea: 0.0 cal/mol}
+  low-P-rate-constant: {A: 2.3e+12, b: -0.9, Ea: -1700.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.7346, T3: 94.0, T1: 1756.0, T2: 5182.0}
+- equation: 2 OH <=> O + H2O
+  rate-constant: {A: 35.7, b: 2.4, Ea: -2110.0 cal/mol}
+- equation: OH + HO2 <=> O2 + H2O
+  rate-constant: {A: 1.45e+10, b: 0.0, Ea: -500.0 cal/mol}
+  duplicate: true
+- equation: OH + H2O2 <=> HO2 + H2O
+  rate-constant: {A: 2.0e+09, b: 0.0, Ea: 427.0 cal/mol}
+  duplicate: true
+- equation: OH + H2O2 <=> HO2 + H2O
+  rate-constant: {A: 1.7e+15, b: 0.0, Ea: 2.941e+04 cal/mol}
+  duplicate: true
+- equation: OH + C <=> H + CO
+  rate-constant: {A: 5.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: OH + CH <=> H + HCO
+  rate-constant: {A: 3.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: OH + CH2 <=> H + CH2O
+  rate-constant: {A: 2.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: OH + CH2 <=> CH + H2O
+  rate-constant: {A: 1.13e+04, b: 2.0, Ea: 3000.0 cal/mol}
+- equation: OH + CH2(S) <=> H + CH2O
+  rate-constant: {A: 3.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: OH + CH3 (+ M) <=> CH3OH (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 2.79e+15, b: -1.43, Ea: 1330.0 cal/mol}
+  low-P-rate-constant: {A: 4.0e+30, b: -5.92, Ea: 3140.0 cal/mol}
+  efficiencies: {C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 6.0}
+  Troe: {A: 0.412, T3: 195.0, T1: 5900.0, T2: 6394.0}
+- equation: OH + CH3 <=> CH2 + H2O
+  rate-constant: {A: 5.6e+04, b: 1.6, Ea: 5420.0 cal/mol}
+- equation: OH + CH3 <=> CH2(S) + H2O
+  rate-constant: {A: 6.44e+14, b: -1.34, Ea: 1417.0 cal/mol}
+- equation: OH + CH4 <=> CH3 + H2O
+  rate-constant: {A: 1.0e+05, b: 1.6, Ea: 3120.0 cal/mol}
+- equation: OH + CO <=> H + CO2
+  rate-constant: {A: 4.76e+04, b: 1.228, Ea: 70.0 cal/mol}
+- equation: OH + HCO <=> H2O + CO
+  rate-constant: {A: 5.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: OH + CH2O <=> HCO + H2O
+  rate-constant: {A: 3.43e+06, b: 1.18, Ea: -447.0 cal/mol}
+- equation: OH + CH2OH <=> H2O + CH2O
+  rate-constant: {A: 5.0e+09, b: 0.0, Ea: 0.0 cal/mol}
+- equation: OH + CH3O <=> H2O + CH2O
+  rate-constant: {A: 5.0e+09, b: 0.0, Ea: 0.0 cal/mol}
+- equation: OH + CH3OH <=> CH2OH + H2O
+  rate-constant: {A: 1440.0, b: 2.0, Ea: -840.0 cal/mol}
+- equation: OH + CH3OH <=> CH3O + H2O
+  rate-constant: {A: 6300.0, b: 2.0, Ea: 1500.0 cal/mol}
+- equation: OH + C2H <=> H + HCCO
+  rate-constant: {A: 2.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: OH + C2H2 <=> H + CH2CO
+  rate-constant: {A: 2.18e-07, b: 4.5, Ea: -1000.0 cal/mol}
+- equation: OH + C2H2 <=> H + HCCOH
+  rate-constant: {A: 504.0, b: 2.3, Ea: 1.35e+04 cal/mol}
+- equation: OH + C2H2 <=> C2H + H2O
+  rate-constant: {A: 3.37e+04, b: 2.0, Ea: 1.4e+04 cal/mol}
+- equation: OH + C2H2 <=> CH3 + CO
+  rate-constant: {A: 4.83e-07, b: 4.0, Ea: -2000.0 cal/mol}
+- equation: OH + C2H3 <=> H2O + C2H2
+  rate-constant: {A: 5.0e+09, b: 0.0, Ea: 0.0 cal/mol}
+- equation: OH + C2H4 <=> C2H3 + H2O
+  rate-constant: {A: 3600.0, b: 2.0, Ea: 2500.0 cal/mol}
+- equation: OH + C2H6 <=> C2H5 + H2O
+  rate-constant: {A: 3540.0, b: 2.12, Ea: 870.0 cal/mol}
+- equation: OH + CH2CO <=> HCCO + H2O
+  rate-constant: {A: 7.5e+09, b: 0.0, Ea: 2000.0 cal/mol}
+- equation: 2 HO2 <=> O2 + H2O2
+  rate-constant: {A: 1.3e+08, b: 0.0, Ea: -1630.0 cal/mol}
+  duplicate: true
+- equation: 2 HO2 <=> O2 + H2O2
+  rate-constant: {A: 4.2e+11, b: 0.0, Ea: 1.2e+04 cal/mol}
+  duplicate: true
+- equation: HO2 + CH2 <=> OH + CH2O
+  rate-constant: {A: 2.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: HO2 + CH3 <=> O2 + CH4
+  rate-constant: {A: 1.0e+09, b: 0.0, Ea: 0.0 cal/mol}
+- equation: HO2 + CH3 <=> OH + CH3O
+  rate-constant: {A: 3.78e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: HO2 + CO <=> OH + CO2
+  rate-constant: {A: 1.5e+11, b: 0.0, Ea: 2.36e+04 cal/mol}
+- equation: HO2 + CH2O <=> HCO + H2O2
+  rate-constant: {A: 5600.0, b: 2.0, Ea: 1.2e+04 cal/mol}
+- equation: C + O2 <=> O + CO
+  rate-constant: {A: 5.8e+10, b: 0.0, Ea: 576.0 cal/mol}
+- equation: C + CH2 <=> H + C2H
+  rate-constant: {A: 5.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: C + CH3 <=> H + C2H2
+  rate-constant: {A: 5.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH + O2 <=> O + HCO
+  rate-constant: {A: 6.71e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH + H2 <=> H + CH2
+  rate-constant: {A: 1.08e+11, b: 0.0, Ea: 3110.0 cal/mol}
+- equation: CH + H2O <=> H + CH2O
+  rate-constant: {A: 5.71e+09, b: 0.0, Ea: -755.0 cal/mol}
+- equation: CH + CH2 <=> H + C2H2
+  rate-constant: {A: 4.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH + CH3 <=> H + C2H3
+  rate-constant: {A: 3.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH + CH4 <=> H + C2H4
+  rate-constant: {A: 6.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH + CO (+ M) <=> HCCO (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 5.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+  low-P-rate-constant: {A: 2.69e+22, b: -3.74, Ea: 1936.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.5757, T3: 237.0, T1: 1652.0, T2: 5069.0}
+- equation: CH + CO2 <=> HCO + CO
+  rate-constant: {A: 1.9e+11, b: 0.0, Ea: 1.5792e+04 cal/mol}
+- equation: CH + CH2O <=> H + CH2CO
+  rate-constant: {A: 9.46e+10, b: 0.0, Ea: -515.0 cal/mol}
+- equation: CH + HCCO <=> CO + C2H2
+  rate-constant: {A: 5.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH2 + O2 => OH + H + CO
+  rate-constant: {A: 5.0e+09, b: 0.0, Ea: 1500.0 cal/mol}
+- equation: CH2 + H2 <=> H + CH3
+  rate-constant: {A: 500.0, b: 2.0, Ea: 7230.0 cal/mol}
+- equation: 2 CH2 <=> H2 + C2H2
+  rate-constant: {A: 1.6e+12, b: 0.0, Ea: 1.1944e+04 cal/mol}
+- equation: CH2 + CH3 <=> H + C2H4
+  rate-constant: {A: 4.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH2 + CH4 <=> 2 CH3
+  rate-constant: {A: 2460.0, b: 2.0, Ea: 8270.0 cal/mol}
+- equation: CH2 + CO (+ M) <=> CH2CO (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 8.1e+08, b: 0.5, Ea: 4510.0 cal/mol}
+  low-P-rate-constant: {A: 2.69e+27, b: -5.11, Ea: 7095.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.5907, T3: 275.0, T1: 1226.0, T2: 5185.0}
+- equation: CH2 + HCCO <=> C2H3 + CO
+  rate-constant: {A: 3.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH2(S) + N2 <=> CH2 + N2
+  rate-constant: {A: 1.5e+10, b: 0.0, Ea: 600.0 cal/mol}
+- equation: CH2(S) + AR <=> CH2 + AR
+  rate-constant: {A: 9.0e+09, b: 0.0, Ea: 600.0 cal/mol}
+- equation: CH2(S) + O2 <=> H + OH + CO
+  rate-constant: {A: 2.8e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH2(S) + O2 <=> CO + H2O
+  rate-constant: {A: 1.2e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH2(S) + H2 <=> CH3 + H
+  rate-constant: {A: 7.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH2(S) + H2O (+ M) <=> CH3OH (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 4.82e+14, b: -1.16, Ea: 1145.0 cal/mol}
+  low-P-rate-constant: {A: 1.88e+32, b: -6.36, Ea: 5040.0 cal/mol}
+  efficiencies: {C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 6.0}
+  Troe: {A: 0.6027, T3: 208.0, T1: 3922.0, T2: 1.018e+04}
+- equation: CH2(S) + H2O <=> CH2 + H2O
+  rate-constant: {A: 3.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH2(S) + CH3 <=> H + C2H4
+  rate-constant: {A: 1.2e+10, b: 0.0, Ea: -570.0 cal/mol}
+- equation: CH2(S) + CH4 <=> 2 CH3
+  rate-constant: {A: 1.6e+10, b: 0.0, Ea: -570.0 cal/mol}
+- equation: CH2(S) + CO <=> CH2 + CO
+  rate-constant: {A: 9.0e+09, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH2(S) + CO2 <=> CH2 + CO2
+  rate-constant: {A: 7.0e+09, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH2(S) + CO2 <=> CO + CH2O
+  rate-constant: {A: 1.4e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH2(S) + C2H6 <=> CH3 + C2H5
+  rate-constant: {A: 4.0e+10, b: 0.0, Ea: -550.0 cal/mol}
+- equation: CH3 + O2 <=> O + CH3O
+  rate-constant: {A: 3.56e+10, b: 0.0, Ea: 3.048e+04 cal/mol}
+- equation: CH3 + O2 <=> OH + CH2O
+  rate-constant: {A: 2.31e+09, b: 0.0, Ea: 2.0315e+04 cal/mol}
+- equation: CH3 + H2O2 <=> HO2 + CH4
+  rate-constant: {A: 24.5, b: 2.47, Ea: 5180.0 cal/mol}
+- equation: 2 CH3 (+ M) <=> C2H6 (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 6.77e+13, b: -1.18, Ea: 654.0 cal/mol}
+  low-P-rate-constant: {A: 3.4e+35, b: -7.03, Ea: 2762.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.619, T3: 73.2, T1: 1180.0, T2: 9999.0}
+- equation: 2 CH3 <=> H + C2H5
+  rate-constant: {A: 6.84e+09, b: 0.1, Ea: 1.06e+04 cal/mol}
+- equation: CH3 + HCO <=> CH4 + CO
+  rate-constant: {A: 2.648e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH3 + CH2O <=> HCO + CH4
+  rate-constant: {A: 3.32, b: 2.81, Ea: 5860.0 cal/mol}
+- equation: CH3 + CH3OH <=> CH2OH + CH4
+  rate-constant: {A: 3.0e+04, b: 1.5, Ea: 9940.0 cal/mol}
+- equation: CH3 + CH3OH <=> CH3O + CH4
+  rate-constant: {A: 1.0e+04, b: 1.5, Ea: 9940.0 cal/mol}
+- equation: CH3 + C2H4 <=> C2H3 + CH4
+  rate-constant: {A: 227.0, b: 2.0, Ea: 9200.0 cal/mol}
+- equation: CH3 + C2H6 <=> C2H5 + CH4
+  rate-constant: {A: 6140.0, b: 1.74, Ea: 1.045e+04 cal/mol}
+- equation: HCO + H2O <=> H + CO + H2O
+  rate-constant: {A: 1.5e+15, b: -1.0, Ea: 1.7e+04 cal/mol}
+- equation: HCO + M <=> H + CO + M
+  type: three-body
+  rate-constant: {A: 1.87e+14, b: -1.0, Ea: 1.7e+04 cal/mol}
+  efficiencies: {C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 0.0}
+- equation: HCO + O2 <=> HO2 + CO
+  rate-constant: {A: 1.345e+10, b: 0.0, Ea: 400.0 cal/mol}
+- equation: CH2OH + O2 <=> HO2 + CH2O
+  rate-constant: {A: 1.8e+10, b: 0.0, Ea: 900.0 cal/mol}
+- equation: CH3O + O2 <=> HO2 + CH2O
+  rate-constant: {A: 4.28e-16, b: 7.6, Ea: -3530.0 cal/mol}
+- equation: C2H + O2 <=> HCO + CO
+  rate-constant: {A: 1.0e+10, b: 0.0, Ea: -755.0 cal/mol}
+- equation: C2H + H2 <=> H + C2H2
+  rate-constant: {A: 5.68e+07, b: 0.9, Ea: 1993.0 cal/mol}
+- equation: C2H3 + O2 <=> HCO + CH2O
+  rate-constant: {A: 4.58e+13, b: -1.39, Ea: 1015.0 cal/mol}
+- equation: C2H4 (+ M) <=> H2 + C2H2 (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 8.0e+12, b: 0.44, Ea: 8.677e+04 cal/mol}
+  low-P-rate-constant: {A: 1.58e+48, b: -9.3, Ea: 9.78e+04 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.7345, T3: 180.0, T1: 1035.0, T2: 5417.0}
+- equation: C2H5 + O2 <=> HO2 + C2H4
+  rate-constant: {A: 8.4e+08, b: 0.0, Ea: 3875.0 cal/mol}
+- equation: HCCO + O2 <=> OH + 2 CO
+  rate-constant: {A: 3.2e+09, b: 0.0, Ea: 854.0 cal/mol}
+- equation: 2 HCCO <=> 2 CO + C2H2
+  rate-constant: {A: 1.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: N + NO <=> N2 + O
+  rate-constant: {A: 2.7e+10, b: 0.0, Ea: 355.0 cal/mol}
+- equation: N + O2 <=> NO + O
+  rate-constant: {A: 9.0e+06, b: 1.0, Ea: 6500.0 cal/mol}
+- equation: N + OH <=> NO + H
+  rate-constant: {A: 3.36e+10, b: 0.0, Ea: 385.0 cal/mol}
+- equation: N2O + O <=> N2 + O2
+  rate-constant: {A: 1.4e+09, b: 0.0, Ea: 1.081e+04 cal/mol}
+- equation: N2O + O <=> 2 NO
+  rate-constant: {A: 2.9e+10, b: 0.0, Ea: 2.315e+04 cal/mol}
+- equation: N2O + H <=> N2 + OH
+  rate-constant: {A: 3.87e+11, b: 0.0, Ea: 1.888e+04 cal/mol}
+- equation: N2O + OH <=> N2 + HO2
+  rate-constant: {A: 2.0e+09, b: 0.0, Ea: 2.106e+04 cal/mol}
+- equation: N2O (+ M) <=> N2 + O (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 7.91e+10, b: 0.0, Ea: 5.602e+04 cal/mol}
+  low-P-rate-constant: {A: 6.37e+11, b: 0.0, Ea: 5.664e+04 cal/mol}
+  efficiencies: {AR: 0.625, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+- equation: HO2 + NO <=> NO2 + OH
+  rate-constant: {A: 2.11e+09, b: 0.0, Ea: -480.0 cal/mol}
+- equation: NO + O + M <=> NO2 + M
+  type: three-body
+  rate-constant: {A: 1.06e+14, b: -1.41, Ea: 0.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+- equation: NO2 + O <=> NO + O2
+  rate-constant: {A: 3.9e+09, b: 0.0, Ea: -240.0 cal/mol}
+- equation: NO2 + H <=> NO + OH
+  rate-constant: {A: 1.32e+11, b: 0.0, Ea: 360.0 cal/mol}
+- equation: NH + O <=> NO + H
+  rate-constant: {A: 4.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: NH + H <=> N + H2
+  rate-constant: {A: 3.2e+10, b: 0.0, Ea: 330.0 cal/mol}
+- equation: NH + OH <=> HNO + H
+  rate-constant: {A: 2.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: NH + OH <=> N + H2O
+  rate-constant: {A: 2.0e+06, b: 1.2, Ea: 0.0 cal/mol}
+- equation: NH + O2 <=> HNO + O
+  rate-constant: {A: 461.0, b: 2.0, Ea: 6500.0 cal/mol}
+- equation: NH + O2 <=> NO + OH
+  rate-constant: {A: 1280.0, b: 1.5, Ea: 100.0 cal/mol}
+- equation: NH + N <=> N2 + H
+  rate-constant: {A: 1.5e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: NH + H2O <=> HNO + H2
+  rate-constant: {A: 2.0e+10, b: 0.0, Ea: 1.385e+04 cal/mol}
+- equation: NH + NO <=> N2 + OH
+  rate-constant: {A: 2.16e+10, b: -0.23, Ea: 0.0 cal/mol}
+- equation: NH + NO <=> N2O + H
+  rate-constant: {A: 3.65e+11, b: -0.45, Ea: 0.0 cal/mol}
+- equation: NH2 + O <=> OH + NH
+  rate-constant: {A: 3.0e+09, b: 0.0, Ea: 0.0 cal/mol}
+- equation: NH2 + O <=> H + HNO
+  rate-constant: {A: 3.9e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: NH2 + H <=> NH + H2
+  rate-constant: {A: 4.0e+10, b: 0.0, Ea: 3650.0 cal/mol}
+- equation: NH2 + OH <=> NH + H2O
+  rate-constant: {A: 9.0e+04, b: 1.5, Ea: -460.0 cal/mol}
+- equation: NNH <=> N2 + H
+  rate-constant: {A: 3.3e+08, b: 0.0, Ea: 0.0 cal/mol}
+- equation: NNH + M <=> N2 + H + M
+  type: three-body
+  rate-constant: {A: 1.3e+11, b: -0.11, Ea: 4980.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+- equation: NNH + O2 <=> HO2 + N2
+  rate-constant: {A: 5.0e+09, b: 0.0, Ea: 0.0 cal/mol}
+- equation: NNH + O <=> OH + N2
+  rate-constant: {A: 2.5e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: NNH + O <=> NH + NO
+  rate-constant: {A: 7.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: NNH + H <=> H2 + N2
+  rate-constant: {A: 5.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: NNH + OH <=> H2O + N2
+  rate-constant: {A: 2.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: NNH + CH3 <=> CH4 + N2
+  rate-constant: {A: 2.5e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: H + NO + M <=> HNO + M
+  type: three-body
+  rate-constant: {A: 4.48e+13, b: -1.32, Ea: 740.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+- equation: HNO + O <=> NO + OH
+  rate-constant: {A: 2.5e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: HNO + H <=> H2 + NO
+  rate-constant: {A: 9.0e+08, b: 0.72, Ea: 660.0 cal/mol}
+- equation: HNO + OH <=> NO + H2O
+  rate-constant: {A: 1.3e+04, b: 1.9, Ea: -950.0 cal/mol}
+- equation: HNO + O2 <=> HO2 + NO
+  rate-constant: {A: 1.0e+10, b: 0.0, Ea: 1.3e+04 cal/mol}
+- equation: CN + O <=> CO + N
+  rate-constant: {A: 7.7e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CN + OH <=> NCO + H
+  rate-constant: {A: 4.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CN + H2O <=> HCN + OH
+  rate-constant: {A: 8.0e+09, b: 0.0, Ea: 7460.0 cal/mol}
+- equation: CN + O2 <=> NCO + O
+  rate-constant: {A: 6.14e+09, b: 0.0, Ea: -440.0 cal/mol}
+- equation: CN + H2 <=> HCN + H
+  rate-constant: {A: 295.0, b: 2.45, Ea: 2240.0 cal/mol}
+- equation: NCO + O <=> NO + CO
+  rate-constant: {A: 2.35e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: NCO + H <=> NH + CO
+  rate-constant: {A: 5.4e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: NCO + OH <=> NO + H + CO
+  rate-constant: {A: 2.5e+09, b: 0.0, Ea: 0.0 cal/mol}
+- equation: NCO + N <=> N2 + CO
+  rate-constant: {A: 2.0e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: NCO + O2 <=> NO + CO2
+  rate-constant: {A: 2.0e+09, b: 0.0, Ea: 2.0e+04 cal/mol}
+- equation: NCO + M <=> N + CO + M
+  type: three-body
+  rate-constant: {A: 3.1e+11, b: 0.0, Ea: 5.405e+04 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+- equation: NCO + NO <=> N2O + CO
+  rate-constant: {A: 1.9e+14, b: -1.52, Ea: 740.0 cal/mol}
+- equation: NCO + NO <=> N2 + CO2
+  rate-constant: {A: 3.8e+15, b: -2.0, Ea: 800.0 cal/mol}
+- equation: HCN + M <=> H + CN + M
+  type: three-body
+  rate-constant: {A: 1.04e+26, b: -3.3, Ea: 1.266e+05 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+- equation: HCN + O <=> NCO + H
+  rate-constant: {A: 20.3, b: 2.64, Ea: 4980.0 cal/mol}
+- equation: HCN + O <=> NH + CO
+  rate-constant: {A: 5.07, b: 2.64, Ea: 4980.0 cal/mol}
+- equation: HCN + O <=> CN + OH
+  rate-constant: {A: 3.91e+06, b: 1.58, Ea: 2.66e+04 cal/mol}
+- equation: HCN + OH <=> HOCN + H
+  rate-constant: {A: 1100.0, b: 2.03, Ea: 1.337e+04 cal/mol}
+- equation: HCN + OH <=> HNCO + H
+  rate-constant: {A: 4.4, b: 2.26, Ea: 6400.0 cal/mol}
+- equation: HCN + OH <=> NH2 + CO
+  rate-constant: {A: 0.16, b: 2.56, Ea: 9000.0 cal/mol}
+- equation: H + HCN (+ M) <=> H2CN (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 3.3e+10, b: 0.0, Ea: 0.0 cal/mol}
+  low-P-rate-constant: {A: 1.4e+20, b: -3.4, Ea: 1900.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+- equation: H2CN + N <=> N2 + CH2
+  rate-constant: {A: 6.0e+10, b: 0.0, Ea: 400.0 cal/mol}
+- equation: C + N2 <=> CN + N
+  rate-constant: {A: 6.3e+10, b: 0.0, Ea: 4.602e+04 cal/mol}
+- equation: CH + N2 <=> HCN + N
+  rate-constant: {A: 3.12e+06, b: 0.88, Ea: 2.013e+04 cal/mol}
+- equation: CH + N2 (+ M) <=> HCNN (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 3.1e+09, b: 0.15, Ea: 0.0 cal/mol}
+  low-P-rate-constant: {A: 1.3e+19, b: -3.16, Ea: 740.0 cal/mol}
+  efficiencies: {AR: 1.0, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.667, T3: 235.0, T1: 2117.0, T2: 4536.0}
+- equation: CH2 + N2 <=> HCN + NH
+  rate-constant: {A: 1.0e+10, b: 0.0, Ea: 7.4e+04 cal/mol}
+- equation: CH2(S) + N2 <=> NH + HCN
+  rate-constant: {A: 1.0e+08, b: 0.0, Ea: 6.5e+04 cal/mol}
+- equation: C + NO <=> CN + O
+  rate-constant: {A: 1.9e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: C + NO <=> CO + N
+  rate-constant: {A: 2.9e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH + NO <=> HCN + O
+  rate-constant: {A: 4.1e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH + NO <=> H + NCO
+  rate-constant: {A: 1.62e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH + NO <=> N + HCO
+  rate-constant: {A: 2.46e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH2 + NO <=> H + HNCO
+  rate-constant: {A: 3.1e+14, b: -1.38, Ea: 1270.0 cal/mol}
+- equation: CH2 + NO <=> OH + HCN
+  rate-constant: {A: 2.9e+11, b: -0.69, Ea: 760.0 cal/mol}
+- equation: CH2 + NO <=> H + HCNO
+  rate-constant: {A: 3.8e+10, b: -0.36, Ea: 580.0 cal/mol}
+- equation: CH2(S) + NO <=> H + HNCO
+  rate-constant: {A: 3.1e+14, b: -1.38, Ea: 1270.0 cal/mol}
+- equation: CH2(S) + NO <=> OH + HCN
+  rate-constant: {A: 2.9e+11, b: -0.69, Ea: 760.0 cal/mol}
+- equation: CH2(S) + NO <=> H + HCNO
+  rate-constant: {A: 3.8e+10, b: -0.36, Ea: 580.0 cal/mol}
+- equation: CH3 + NO <=> HCN + H2O
+  rate-constant: {A: 9.6e+10, b: 0.0, Ea: 2.88e+04 cal/mol}
+- equation: CH3 + NO <=> H2CN + OH
+  rate-constant: {A: 1.0e+09, b: 0.0, Ea: 2.175e+04 cal/mol}
+- equation: HCNN + O <=> CO + H + N2
+  rate-constant: {A: 2.2e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: HCNN + O <=> HCN + NO
+  rate-constant: {A: 2.0e+09, b: 0.0, Ea: 0.0 cal/mol}
+- equation: HCNN + O2 <=> O + HCO + N2
+  rate-constant: {A: 1.2e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: HCNN + OH <=> H + HCO + N2
+  rate-constant: {A: 1.2e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: HCNN + H <=> CH2 + N2
+  rate-constant: {A: 1.0e+11, b: 0.0, Ea: 0.0 cal/mol}
+- equation: HNCO + O <=> NH + CO2
+  rate-constant: {A: 9.8e+04, b: 1.41, Ea: 8500.0 cal/mol}
+- equation: HNCO + O <=> HNO + CO
+  rate-constant: {A: 1.5e+05, b: 1.57, Ea: 4.4e+04 cal/mol}
+- equation: HNCO + O <=> NCO + OH
+  rate-constant: {A: 2200.0, b: 2.11, Ea: 1.14e+04 cal/mol}
+- equation: HNCO + H <=> NH2 + CO
+  rate-constant: {A: 2.25e+04, b: 1.7, Ea: 3800.0 cal/mol}
+- equation: HNCO + H <=> H2 + NCO
+  rate-constant: {A: 105.0, b: 2.5, Ea: 1.33e+04 cal/mol}
+- equation: HNCO + OH <=> NCO + H2O
+  rate-constant: {A: 3.3e+04, b: 1.5, Ea: 3600.0 cal/mol}
+- equation: HNCO + OH <=> NH2 + CO2
+  rate-constant: {A: 3300.0, b: 1.5, Ea: 3600.0 cal/mol}
+- equation: HNCO + M <=> NH + CO + M
+  type: three-body
+  rate-constant: {A: 1.18e+13, b: 0.0, Ea: 8.472e+04 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+- equation: HCNO + H <=> H + HNCO
+  rate-constant: {A: 2.1e+12, b: -0.69, Ea: 2850.0 cal/mol}
+- equation: HCNO + H <=> OH + HCN
+  rate-constant: {A: 2.7e+08, b: 0.18, Ea: 2120.0 cal/mol}
+- equation: HCNO + H <=> NH2 + CO
+  rate-constant: {A: 1.7e+11, b: -0.75, Ea: 2890.0 cal/mol}
+- equation: HOCN + H <=> H + HNCO
+  rate-constant: {A: 2.0e+04, b: 2.0, Ea: 2000.0 cal/mol}
+- equation: HCCO + NO <=> HCNO + CO
+  rate-constant: {A: 9.0e+09, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH3 + N <=> H2CN + H
+  rate-constant: {A: 6.1e+11, b: -0.31, Ea: 290.0 cal/mol}
+- equation: CH3 + N <=> HCN + H2
+  rate-constant: {A: 3.7e+09, b: 0.15, Ea: -90.0 cal/mol}
+- equation: NH3 + H <=> NH2 + H2
+  rate-constant: {A: 540.0, b: 2.4, Ea: 9915.0 cal/mol}
+- equation: NH3 + OH <=> NH2 + H2O
+  rate-constant: {A: 5.0e+04, b: 1.6, Ea: 955.0 cal/mol}
+- equation: NH3 + O <=> NH2 + OH
+  rate-constant: {A: 9400.0, b: 1.94, Ea: 6460.0 cal/mol}
+- equation: NH + CO2 <=> HNO + CO
+  rate-constant: {A: 1.0e+10, b: 0.0, Ea: 1.435e+04 cal/mol}
+- equation: CN + NO2 <=> NCO + NO
+  rate-constant: {A: 6.16e+12, b: -0.752, Ea: 345.0 cal/mol}
+- equation: NCO + NO2 <=> N2O + CO2
+  rate-constant: {A: 3.25e+09, b: 0.0, Ea: -705.0 cal/mol}
+- equation: N + CO2 <=> NO + CO
+  rate-constant: {A: 3.0e+09, b: 0.0, Ea: 1.13e+04 cal/mol}
+- equation: O + CH3 => H + H2 + CO
+  rate-constant: {A: 3.37e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O + C2H4 <=> H + CH2CHO
+  rate-constant: {A: 6700.0, b: 1.83, Ea: 220.0 cal/mol}
+- equation: O + C2H5 <=> H + CH3CHO
+  rate-constant: {A: 1.096e+11, b: 0.0, Ea: 0.0 cal/mol}
+- equation: OH + HO2 <=> O2 + H2O
+  rate-constant: {A: 5.0e+12, b: 0.0, Ea: 1.733e+04 cal/mol}
+  duplicate: true
+- equation: OH + CH3 => H2 + CH2O
+  rate-constant: {A: 8.0e+06, b: 0.5, Ea: -1755.0 cal/mol}
+- equation: CH + H2 (+ M) <=> CH3 (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 1.97e+09, b: 0.43, Ea: -370.0 cal/mol}
+  low-P-rate-constant: {A: 4.82e+19, b: -2.8, Ea: 590.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.578, T3: 122.0, T1: 2535.0, T2: 9365.0}
+- equation: CH2 + O2 => 2 H + CO2
+  rate-constant: {A: 5.8e+09, b: 0.0, Ea: 1500.0 cal/mol}
+- equation: CH2 + O2 <=> O + CH2O
+  rate-constant: {A: 2.4e+09, b: 0.0, Ea: 1500.0 cal/mol}
+- equation: CH2 + CH2 => 2 H + C2H2
+  rate-constant: {A: 2.0e+11, b: 0.0, Ea: 1.0989e+04 cal/mol}
+- equation: CH2(S) + H2O => H2 + CH2O
+  rate-constant: {A: 6.82e+07, b: 0.25, Ea: -935.0 cal/mol}
+- equation: C2H3 + O2 <=> O + CH2CHO
+  rate-constant: {A: 3.03e+08, b: 0.29, Ea: 11.0 cal/mol}
+- equation: C2H3 + O2 <=> HO2 + C2H2
+  rate-constant: {A: 1337.0, b: 1.61, Ea: -384.0 cal/mol}
+- equation: O + CH3CHO <=> OH + CH2CHO
+  rate-constant: {A: 5.84e+09, b: 0.0, Ea: 1808.0 cal/mol}
+- equation: O + CH3CHO => OH + CH3 + CO
+  rate-constant: {A: 5.84e+09, b: 0.0, Ea: 1808.0 cal/mol}
+- equation: O2 + CH3CHO => HO2 + CH3 + CO
+  rate-constant: {A: 3.01e+10, b: 0.0, Ea: 3.915e+04 cal/mol}
+- equation: H + CH3CHO <=> CH2CHO + H2
+  rate-constant: {A: 2.05e+06, b: 1.16, Ea: 2405.0 cal/mol}
+- equation: H + CH3CHO => CH3 + H2 + CO
+  rate-constant: {A: 2.05e+06, b: 1.16, Ea: 2405.0 cal/mol}
+- equation: OH + CH3CHO => CH3 + H2O + CO
+  rate-constant: {A: 2.343e+07, b: 0.73, Ea: -1113.0 cal/mol}
+- equation: HO2 + CH3CHO => CH3 + H2O2 + CO
+  rate-constant: {A: 3.01e+09, b: 0.0, Ea: 1.1923e+04 cal/mol}
+- equation: CH3 + CH3CHO => CH3 + CH4 + CO
+  rate-constant: {A: 2720.0, b: 1.77, Ea: 5920.0 cal/mol}
+- equation: H + CH2CO (+ M) <=> CH2CHO (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 4.865e+08, b: 0.422, Ea: -1755.0 cal/mol}
+  low-P-rate-constant: {A: 1.012e+36, b: -7.63, Ea: 3854.0 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.465, T3: 201.0, T1: 1773.0, T2: 5333.0}
+- equation: O + CH2CHO => H + CH2 + CO2
+  rate-constant: {A: 1.5e+11, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O2 + CH2CHO => OH + CO + CH2O
+  rate-constant: {A: 1.81e+07, b: 0.0, Ea: 0.0 cal/mol}
+- equation: O2 + CH2CHO => OH + 2 HCO
+  rate-constant: {A: 2.35e+07, b: 0.0, Ea: 0.0 cal/mol}
+- equation: H + CH2CHO <=> CH3 + HCO
+  rate-constant: {A: 2.2e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: H + CH2CHO <=> CH2CO + H2
+  rate-constant: {A: 1.1e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: OH + CH2CHO <=> H2O + CH2CO
+  rate-constant: {A: 1.2e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: OH + CH2CHO <=> HCO + CH2OH
+  rate-constant: {A: 3.01e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH3 + C2H5 (+ M) <=> C3H8 (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 9.43e+09, b: 0.0, Ea: 0.0 cal/mol}
+  low-P-rate-constant: {A: 2.71e+68, b: -16.82, Ea: 1.3065e+04 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.1527, T3: 291.0, T1: 2742.0, T2: 7748.0}
+- equation: O + C3H8 <=> OH + C3H7
+  rate-constant: {A: 193.0, b: 2.68, Ea: 3716.0 cal/mol}
+- equation: H + C3H8 <=> C3H7 + H2
+  rate-constant: {A: 1320.0, b: 2.54, Ea: 6756.0 cal/mol}
+- equation: OH + C3H8 <=> C3H7 + H2O
+  rate-constant: {A: 3.16e+04, b: 1.8, Ea: 934.0 cal/mol}
+- equation: C3H7 + H2O2 <=> HO2 + C3H8
+  rate-constant: {A: 0.378, b: 2.72, Ea: 1500.0 cal/mol}
+- equation: CH3 + C3H8 <=> C3H7 + CH4
+  rate-constant: {A: 9.03e-04, b: 3.65, Ea: 7154.0 cal/mol}
+- equation: CH3 + C2H4 (+ M) <=> C3H7 (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 2550.0, b: 1.6, Ea: 5700.0 cal/mol}
+  low-P-rate-constant: {A: 3.0e+57, b: -14.6, Ea: 1.817e+04 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.1894, T3: 277.0, T1: 8748.0, T2: 7891.0}
+- equation: O + C3H7 <=> C2H5 + CH2O
+  rate-constant: {A: 9.64e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: H + C3H7 (+ M) <=> C3H8 (+ M)
+  type: falloff
+  high-P-rate-constant: {A: 3.613e+10, b: 0.0, Ea: 0.0 cal/mol}
+  low-P-rate-constant: {A: 4.42e+55, b: -13.545, Ea: 1.1357e+04 cal/mol}
+  efficiencies: {AR: 0.7, C2H6: 3.0, CH4: 2.0, CO: 1.5, CO2: 2.0, H2: 2.0, H2O: 
+      6.0}
+  Troe: {A: 0.315, T3: 369.0, T1: 3285.0, T2: 6667.0}
+- equation: H + C3H7 <=> CH3 + C2H5
+  rate-constant: {A: 4060.0, b: 2.19, Ea: 890.0 cal/mol}
+- equation: OH + C3H7 <=> C2H5 + CH2OH
+  rate-constant: {A: 2.41e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: HO2 + C3H7 <=> O2 + C3H8
+  rate-constant: {A: 2.55e+07, b: 0.255, Ea: -943.0 cal/mol}
+- equation: HO2 + C3H7 => OH + C2H5 + CH2O
+  rate-constant: {A: 2.41e+10, b: 0.0, Ea: 0.0 cal/mol}
+- equation: CH3 + C3H7 <=> 2 C2H5
+  rate-constant: {A: 1.927e+10, b: -0.32, Ea: 0.0 cal/mol}

--- a/gnn/__init__.py
+++ b/gnn/__init__.py
@@ -1,0 +1,9 @@
+from .models import SpeciesGCN, SpeciesGAT, train_dummy_gnn, predict_scores, graph_to_data
+
+__all__ = [
+    "SpeciesGCN",
+    "SpeciesGAT",
+    "train_dummy_gnn",
+    "predict_scores",
+    "graph_to_data",
+]

--- a/gnn/models.py
+++ b/gnn/models.py
@@ -1,0 +1,58 @@
+import torch
+from torch import nn
+from torch_geometric.nn import GCNConv, GATConv
+
+class SpeciesGCN(nn.Module):
+    def __init__(self, in_dim: int, hidden: int):
+        super().__init__()
+        self.conv1 = GCNConv(in_dim, hidden)
+        self.conv2 = GCNConv(hidden, 1)
+
+    def forward(self, x, edge_index):
+        h = torch.relu(self.conv1(x, edge_index))
+        return torch.sigmoid(self.conv2(h, edge_index))
+
+class SpeciesGAT(nn.Module):
+    def __init__(self, in_dim: int, hidden: int):
+        super().__init__()
+        self.conv1 = GATConv(in_dim, hidden, heads=2)
+        self.conv2 = GATConv(2*hidden, 1, heads=1)
+
+    def forward(self, x, edge_index):
+        h = torch.relu(self.conv1(x, edge_index))
+        return torch.sigmoid(self.conv2(h, edge_index))
+
+from torch_geometric.data import Data
+import networkx as nx
+
+def graph_to_data(G: nx.DiGraph) -> Data:
+    mapping = {n: i for i, n in enumerate(G.nodes)}
+    edges = [[mapping[u], mapping[v]] for u, v in G.edges]
+    edge_index = torch.tensor(edges, dtype=torch.long).t().contiguous()
+    x = []
+    for n in G.nodes:
+        x.append([G.out_degree(n), G.in_degree(n)])
+    x = torch.tensor(x, dtype=torch.float)
+    return Data(x=x, edge_index=edge_index)
+
+
+def train_dummy_gnn(G: nx.DiGraph, epochs: int = 10) -> SpeciesGCN:
+    """Train a simple GCN on random targets to demonstrate workflow."""
+    data = graph_to_data(G)
+    model = SpeciesGCN(in_dim=2, hidden=4)
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+    y = torch.rand(len(G.nodes), 1)
+    for _ in range(epochs):
+        optimizer.zero_grad()
+        out = model(data.x, data.edge_index)
+        loss = nn.functional.mse_loss(out, y)
+        loss.backward()
+        optimizer.step()
+    return model
+
+
+def predict_scores(model: nn.Module, G: nx.DiGraph) -> dict:
+    data = graph_to_data(G)
+    with torch.no_grad():
+        scores = model(data.x, data.edge_index).squeeze().cpu().numpy()
+    return {n: float(s) for n, s in zip(G.nodes, scores)}

--- a/graph/__init__.py
+++ b/graph/__init__.py
@@ -1,0 +1,6 @@
+from .construction import build_species_graph, save_graphml
+
+__all__ = [
+    "build_species_graph",
+    "save_graphml",
+]

--- a/graph/construction.py
+++ b/graph/construction.py
@@ -1,0 +1,40 @@
+import networkx as nx
+from typing import Dict, Optional
+from cantera import Solution
+
+
+def build_species_graph(solution: Solution, weights: Dict[str, float] = None, node_scores: Optional[Dict[str, float]] = None) -> nx.DiGraph:
+    """Create a directed graph where nodes are species and edges are reactions.
+
+    Parameters
+    ----------
+    solution:
+        Cantera Solution object.
+    weights:
+        Optional dictionary mapping reaction types to edge weights.
+    node_scores:
+        Optional mapping of species names to importance scores; if provided, edge
+        weights are averaged from connected node scores.
+    """
+    G = nx.DiGraph()
+    for sp in solution.species_names:
+        score = 1.0
+        if node_scores and sp in node_scores:
+            score = node_scores[sp]
+        G.add_node(sp, score=score)
+    for i, rxn in enumerate(solution.reactions()):
+        for reactant in rxn.reactants.keys():
+            for product in rxn.products.keys():
+                weight = 1.0
+                if node_scores:
+                    w_r = G.nodes[reactant]["score"]
+                    w_p = G.nodes[product]["score"]
+                    weight = (w_r + w_p) / 2
+                if weights and rxn.reaction_type in weights:
+                    weight *= weights[rxn.reaction_type]
+                G.add_edge(reactant, product, reaction=i, weight=weight)
+    return G
+
+
+def save_graphml(G: nx.DiGraph, path: str):
+    nx.write_graphml(G, path)

--- a/mechanism/__init__.py
+++ b/mechanism/__init__.py
@@ -1,0 +1,4 @@
+from .loader import Mechanism
+from .editor import remove_species_cti, remove_reactions_cti
+
+__all__ = ["Mechanism", "remove_species_cti", "remove_reactions_cti"]

--- a/mechanism/editor.py
+++ b/mechanism/editor.py
@@ -1,0 +1,32 @@
+"""Utilities for editing CTI mechanism files."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def remove_species_cti(cti_path: str, species: Iterable[str], out_path: str) -> None:
+    """Remove species from a CTI file and write to ``out_path``."""
+    with open(cti_path) as f:
+        lines = f.readlines()
+
+    with open(out_path, "w") as f:
+        for line in lines:
+            if any(sp in line and line.strip().startswith("species") for sp in species):
+                continue
+            f.write(line)
+
+
+def remove_reactions_cti(cti_path: str, indices: Iterable[int], out_path: str) -> None:
+    """Remove reactions by index from a CTI file."""
+    with open(cti_path) as f:
+        lines = f.readlines()
+
+    current = -1
+    with open(out_path, "w") as f:
+        for line in lines:
+            if line.strip().startswith("reaction"):
+                current += 1
+            if current in indices:
+                continue
+            f.write(line)

--- a/mechanism/loader.py
+++ b/mechanism/loader.py
@@ -1,0 +1,30 @@
+import cantera as ct
+from typing import List, Dict
+
+class Mechanism:
+    """Wrapper around Cantera Solution for mechanism editing."""
+
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+        self.solution = ct.Solution(file_path)
+
+    @property
+    def species_names(self) -> List[str]:
+        return [s.name for s in self.solution.species()]
+
+    def molecular_weights(self) -> Dict[str, float]:
+        return {s.name: s.molecular_weight for s in self.solution.species()}
+
+    def reactions(self) -> List[ct.Reaction]:
+        return list(self.solution.reactions())
+
+    def remove_species(self, species_list: List[str]):
+        remaining_species = [s for s in self.solution.species() if s.name not in species_list]
+        self.solution = ct.Solution(thermo='IdealGas', kinetics='GasKinetics', species=remaining_species, reactions=self.solution.reactions())
+
+    def remove_reactions(self, indexes: List[int]):
+        reactions = [r for i, r in enumerate(self.solution.reactions()) if i not in indexes]
+        self.solution = ct.Solution(thermo='IdealGas', kinetics='GasKinetics', species=self.solution.species(), reactions=reactions)
+
+    def save(self, out_path: str):
+        ct.save(out_path, self.solution)

--- a/metaheuristics/__init__.py
+++ b/metaheuristics/__init__.py
@@ -1,0 +1,15 @@
+from .ga import run_ga, GAOptions
+from .abc import run_abc, ABCOptions
+from .bees import run_bees, BeesOptions
+from .bnb import run_bnb, BnBOptions
+
+__all__ = [
+    "run_ga",
+    "GAOptions",
+    "run_abc",
+    "ABCOptions",
+    "run_bees",
+    "BeesOptions",
+    "run_bnb",
+    "BnBOptions",
+]

--- a/metaheuristics/abc.py
+++ b/metaheuristics/abc.py
@@ -1,0 +1,62 @@
+import numpy as np
+from dataclasses import dataclass
+from typing import Callable, List, Tuple
+
+from .ga import initialize_population, fitness
+
+@dataclass
+class ABCOptions:
+    food_count: int = 10
+    limit: int = 5
+    iterations: int = 20
+
+def _neighbour(ind: np.ndarray) -> np.ndarray:
+    new = ind.copy()
+    idx = np.random.randint(len(ind))
+    new[idx] = 1 - new[idx]
+    return new
+
+def run_abc(genome_length: int, eval_fn: Callable[[np.ndarray], float], options: ABCOptions = ABCOptions()) -> Tuple[np.ndarray, List[float]]:
+    """Artificial Bee Colony algorithm."""
+    foods = initialize_population(options.food_count, genome_length)
+    fits = fitness(foods, eval_fn)
+    trials = np.zeros(options.food_count, dtype=int)
+    best_idx = fits.argmax()
+    best_food = foods[best_idx].copy()
+    best_fit = fits[best_idx]
+    history: List[float] = [best_fit]
+    for _ in range(options.iterations):
+        # Employed bees
+        for i in range(options.food_count):
+            candidate = _neighbour(foods[i])
+            cand_fit = eval_fn(candidate)
+            if cand_fit > fits[i]:
+                foods[i] = candidate
+                fits[i] = cand_fit
+                trials[i] = 0
+            else:
+                trials[i] += 1
+        # Onlooker bees
+        prob = fits / fits.sum()
+        for _ in range(options.food_count):
+            i = np.random.choice(options.food_count, p=prob)
+            candidate = _neighbour(foods[i])
+            cand_fit = eval_fn(candidate)
+            if cand_fit > fits[i]:
+                foods[i] = candidate
+                fits[i] = cand_fit
+                trials[i] = 0
+            else:
+                trials[i] += 1
+        # Scout bees
+        for i in range(options.food_count):
+            if trials[i] >= options.limit:
+                foods[i] = initialize_population(1, genome_length)[0]
+                fits[i] = eval_fn(foods[i])
+                trials[i] = 0
+        idx = fits.argmax()
+        if fits[idx] > best_fit:
+            best_fit = fits[idx]
+            best_food = foods[idx].copy()
+        history.append(best_fit)
+    return best_food, history

--- a/metaheuristics/bees.py
+++ b/metaheuristics/bees.py
@@ -1,0 +1,56 @@
+import numpy as np
+from dataclasses import dataclass
+from typing import Callable, List, Tuple
+
+from .ga import initialize_population, fitness
+
+@dataclass
+class BeesOptions:
+    num_bees: int = 20
+    elite_sites: int = 3
+    selected_sites: int = 5
+    elite_bees: int = 7
+    other_bees: int = 3
+    iterations: int = 20
+
+def _neighbour(ind: np.ndarray) -> np.ndarray:
+    new = ind.copy()
+    idx = np.random.randint(len(ind))
+    new[idx] = 1 - new[idx]
+    return new
+
+def run_bees(genome_length: int, eval_fn: Callable[[np.ndarray], float], options: BeesOptions = BeesOptions()) -> Tuple[np.ndarray, List[float]]:
+    """Bees Algorithm implementation."""
+    population = initialize_population(options.num_bees, genome_length)
+    scores = fitness(population, eval_fn)
+    best_idx = scores.argmax()
+    best = population[best_idx].copy()
+    best_score = scores[best_idx]
+    history: List[float] = [best_score]
+    for _ in range(options.iterations):
+        order = np.argsort(-scores)
+        new_pop = []
+        # elite sites
+        for i in order[:options.elite_sites]:
+            site = population[i]
+            neighbs = [site] + [_neighbour(site) for _ in range(options.elite_bees)]
+            fits = fitness(np.array(neighbs), eval_fn)
+            new_pop.append(neighbs[fits.argmax()])
+        # selected sites
+        for i in order[options.elite_sites:options.selected_sites]:
+            site = population[i]
+            neighbs = [site] + [_neighbour(site) for _ in range(options.other_bees)]
+            fits = fitness(np.array(neighbs), eval_fn)
+            new_pop.append(neighbs[fits.argmax()])
+        # remaining bees random search
+        remaining = options.num_bees - len(new_pop)
+        if remaining > 0:
+            new_pop.extend(initialize_population(remaining, genome_length))
+        population = np.array(new_pop)
+        scores = fitness(population, eval_fn)
+        idx = scores.argmax()
+        if scores[idx] > best_score:
+            best_score = scores[idx]
+            best = population[idx].copy()
+        history.append(best_score)
+    return best, history

--- a/metaheuristics/bnb.py
+++ b/metaheuristics/bnb.py
@@ -1,0 +1,32 @@
+import numpy as np
+from dataclasses import dataclass
+from typing import Callable, List, Tuple
+
+@dataclass
+class BnBOptions:
+    max_size: int = 10
+
+
+def run_bnb(genome_length: int, eval_fn: Callable[[np.ndarray], float], options: BnBOptions = BnBOptions()) -> Tuple[np.ndarray, List[float]]:
+    """Branch and Bound exhaustive search for small genomes."""
+    if genome_length > options.max_size:
+        raise ValueError("Genome too large for branch-and-bound")
+    best: np.ndarray = np.zeros(genome_length, dtype=int)
+    best_score = -np.inf
+    history: List[float] = []
+
+    def dfs(prefix: List[int], idx: int):
+        nonlocal best_score, best
+        if idx == genome_length:
+            ind = np.array(prefix)
+            score = eval_fn(ind)
+            history.append(score)
+            if score > best_score:
+                best_score = score
+                best = ind.copy()
+            return
+        dfs(prefix + [0], idx + 1)
+        dfs(prefix + [1], idx + 1)
+
+    dfs([], 0)
+    return best, history

--- a/metaheuristics/ga.py
+++ b/metaheuristics/ga.py
@@ -1,0 +1,77 @@
+import numpy as np
+from dataclasses import dataclass
+from typing import Callable, List, Tuple
+
+@dataclass
+class GAOptions:
+    population_size: int = 20
+    generations: int = 10
+    crossover_rate: float = 0.8
+    mutation_rate: float = 0.1
+
+
+def initialize_population(pop_size: int, genome_length: int) -> np.ndarray:
+    return np.random.randint(0, 2, size=(pop_size, genome_length))
+
+
+def fitness(population: np.ndarray, eval_fn: Callable[[np.ndarray], float]) -> np.ndarray:
+    return np.array([eval_fn(ind) for ind in population])
+
+
+def selection(population: np.ndarray, scores: np.ndarray) -> np.ndarray:
+    probs = scores / scores.sum()
+    idx = np.random.choice(len(population), size=len(population), p=probs)
+    return population[idx]
+
+
+def crossover(population: np.ndarray, rate: float) -> np.ndarray:
+    next_pop = population.copy()
+    for i in range(0, len(population), 2):
+        if np.random.rand() < rate and i+1 < len(population):
+            point = np.random.randint(1, population.shape[1])
+            next_pop[i, point:], next_pop[i+1, point:] = population[i+1, point:].copy(), population[i, point:].copy()
+    return next_pop
+
+
+def mutate(population: np.ndarray, rate: float) -> np.ndarray:
+    mutation = np.random.rand(*population.shape) < rate
+    population[mutation] = 1 - population[mutation]
+    return population
+
+
+def run_ga(
+    genome_length: int,
+    eval_fn: Callable[[np.ndarray], float],
+    options: GAOptions = GAOptions(),
+) -> Tuple[np.ndarray, List[float]]:
+    """Run a simple genetic algorithm.
+
+    Parameters
+    ----------
+    genome_length:
+        Length of the binary genome.
+    eval_fn:
+        Callable evaluating a genome and returning a fitness score.
+    options:
+        Algorithm options.
+
+    Returns
+    -------
+    Tuple[np.ndarray, List[float]]
+        Best genome found and list of best scores per generation.
+    """
+
+    pop = initialize_population(options.population_size, genome_length)
+    best = pop[0]
+    best_score = -np.inf
+    history: List[float] = []
+    for _ in range(options.generations):
+        scores = fitness(pop, eval_fn)
+        if scores.max() > best_score:
+            best_score = scores.max()
+            best = pop[scores.argmax()].copy()
+        history.append(float(best_score))
+        pop = selection(pop, scores)
+        pop = crossover(pop, options.crossover_rate)
+        pop = mutate(pop, options.mutation_rate)
+    return best, history

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,11 @@
+"""Distance metrics for reactor comparison."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def l2_distance(Y_full: np.ndarray, Y_red: np.ndarray, time: np.ndarray) -> float:
+    """Integrate squared difference over time."""
+    diff = Y_full - Y_red
+    return float(np.trapz(np.sum(diff**2, axis=1), time))

--- a/progress_variable.py
+++ b/progress_variable.py
@@ -1,0 +1,72 @@
+"""Utility functions for progress variable calculations."""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Iterable, Sequence
+
+
+def progress_variable(Y: np.ndarray, weights: Sequence[float]) -> np.ndarray:
+    """Return :math:`PV(t)=\sum_i w_i Y_i(t)`.
+
+    Parameters
+    ----------
+    Y:
+        Matrix of mass fractions with shape ``(n_steps, n_species)``.
+    weights:
+        Sequence of species weights ``w_i``.
+
+    Returns
+    -------
+    np.ndarray
+        Progress variable as a one-dimensional array of length ``n_steps``.
+    """
+
+    W = np.asarray(weights, dtype=float)
+    if Y.shape[1] != W.size:
+        raise ValueError("Weight length must match number of species")
+    return (Y * W[None, :]).sum(axis=1)
+
+
+def optimise_weights(
+    Y: np.ndarray,
+    pv_ref: np.ndarray,
+    eval_options: "GAOptions | None" = None,
+) -> np.ndarray:
+    """Optimise progress-variable weights via a genetic algorithm.
+
+    The optimisation minimises the L2 error between ``progress_variable(Y, w)``
+    and a reference progress variable ``pv_ref``.
+
+    Parameters
+    ----------
+    Y:
+        Mass-fraction matrix ``(n_steps, n_species)``.
+    pv_ref:
+        Reference progress variable of length ``n_steps``.
+    eval_options:
+        Optional :class:`~metaheuristics.ga.GAOptions` to control the GA.
+
+    Returns
+    -------
+    np.ndarray
+        Optimised weight vector ``w``.
+    """
+
+    from metaheuristics.ga import GAOptions, run_ga
+
+    options = eval_options or GAOptions()
+
+    genome_length = Y.shape[1]
+
+    def eval_fn(genome: np.ndarray) -> float:
+        # map binary genome to weights in [0, 1]
+        w = genome.astype(float)
+        pv = progress_variable(Y, w)
+        err = np.linalg.norm(pv - pv_ref) / (np.linalg.norm(pv_ref) + 1e-12)
+        # GA maximises fitness, so return negative error
+        return -err
+
+    best, _ = run_ga(genome_length, eval_fn, options)
+    return best.astype(float)
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -p no:warnings
+norecursedirs = arnab_repo

--- a/reactor/__init__.py
+++ b/reactor/__init__.py
@@ -1,0 +1,18 @@
+"""Reactor models for mechanism reduction."""
+
+from .batch import BatchResult, run_constant_pressure, run_constant_volume
+from .piston import run_piston, PistonOptions
+from .network import run_network, Connection
+from .flame import counterflow_flame, CounterFlowOptions
+
+__all__ = [
+    "BatchResult",
+    "run_constant_pressure",
+    "run_constant_volume",
+    "run_piston",
+    "PistonOptions",
+    "run_network",
+    "Connection",
+    "counterflow_flame",
+    "CounterFlowOptions",
+]

--- a/reactor/batch.py
+++ b/reactor/batch.py
@@ -1,0 +1,63 @@
+import cantera as ct
+import numpy as np
+from dataclasses import dataclass
+from typing import Callable, Tuple, Optional
+
+@dataclass
+class BatchResult:
+    """Result of a batch reactor simulation."""
+
+    time: np.ndarray
+    temperature: np.ndarray
+    mass_fractions: np.ndarray
+    ignition_delay: Optional[float] = None
+
+
+def run_constant_pressure(gas: ct.Solution, T0: float, P0: float, Y0: dict, tf: float, nsteps: int = 1000) -> BatchResult:
+    gas.TPY = T0, P0, Y0
+    reactor = ct.IdealGasConstPressureReactor(gas)
+    sim = ct.ReactorNet([reactor])
+    time = []
+    T = []
+    Y = []
+    dt = tf/nsteps
+    for _ in range(nsteps):
+        sim.advance(sim.time + dt)
+        time.append(sim.time)
+        T.append(reactor.T)
+        Y.append(reactor.Y)
+    return BatchResult(np.array(time), np.array(T), np.array(Y))
+
+
+def run_constant_volume(
+    gas: ct.Solution,
+    T0: float,
+    P0: float,
+    Y0: dict,
+    tf: float,
+    nsteps: int = 1000,
+    detect_ignition: bool = True,
+) -> BatchResult:
+    """Integrate a constant-volume adiabatic reactor."""
+
+    gas.TPY = T0, P0, Y0
+    reactor = ct.IdealGasReactor(gas)
+    sim = ct.ReactorNet([reactor])
+    time = []
+    T = []
+    Y = []
+    delay = None
+    last_dTdt = 0.0
+    dt = tf / nsteps
+    for _ in range(nsteps):
+        sim.advance(sim.time + dt)
+        time.append(sim.time)
+        T.append(reactor.T)
+        Y.append(reactor.Y)
+        if detect_ignition:
+            dTdt = (reactor.T - T[-2]) / dt if len(T) > 1 else 0.0
+            if last_dTdt > 0 and dTdt <= 0 and delay is None:
+                delay = time[-2]
+            last_dTdt = dTdt
+
+    return BatchResult(np.array(time), np.array(T), np.array(Y), ignition_delay=delay)

--- a/reactor/flame.py
+++ b/reactor/flame.py
@@ -1,0 +1,24 @@
+"""One-dimensional flame solver wrappers using Cantera."""
+
+from __future__ import annotations
+
+import cantera as ct
+import numpy as np
+from dataclasses import dataclass
+
+
+@dataclass
+class CounterFlowOptions:
+    width: float = 0.02
+    grid: int = 20
+
+
+def counterflow_flame(fuel: ct.Solution, oxidizer: ct.Solution, options: CounterFlowOptions = CounterFlowOptions()) -> ct.CounterflowDiffusionFlame:
+    """Solve a simple counter-flow diffusion flame."""
+
+    gas = ct.Solution('gri30.yaml') if isinstance(fuel, str) else fuel
+    flame = ct.CounterflowDiffusionFlame(gas, width=options.width)
+    flame.grid = np.linspace(0, options.width, options.grid)
+    flame.set_initial_guess(fuel=fuel, oxidizer=oxidizer)
+    flame.solve(loglevel=0, auto=True)
+    return flame

--- a/reactor/network.py
+++ b/reactor/network.py
@@ -1,0 +1,38 @@
+"""Simple reactor network handling multiple connected reactors."""
+
+from __future__ import annotations
+
+import cantera as ct
+import numpy as np
+from dataclasses import dataclass
+from typing import List
+
+from .batch import BatchResult
+
+
+@dataclass
+class Connection:
+    source: int
+    target: int
+    rate: float  # mass flow rate [kg/s]
+
+
+def run_network(gas: ct.Solution, reactors: List[ct.Reactor], connections: List[Connection], tf: float, nsteps: int = 1000) -> List[BatchResult]:
+    """Integrate a simple network of reactors."""
+
+    sim = ct.ReactorNet(reactors)
+    results = [BatchResult(np.zeros(nsteps), np.zeros(nsteps), np.zeros((nsteps, len(gas.species_names)))) for _ in reactors]
+
+    dt = tf / nsteps
+    for step in range(nsteps):
+        sim.advance(sim.time + dt)
+        for conn in connections:
+            mdot = conn.rate
+            reactors[conn.target].mass += mdot * dt
+            reactors[conn.source].mass -= mdot * dt
+        for i, r in enumerate(reactors):
+            results[i].time[step] = sim.time
+            results[i].temperature[step] = r.T
+            results[i].mass_fractions[step, :] = r.thermo.Y
+
+    return results

--- a/reactor/piston.py
+++ b/reactor/piston.py
@@ -1,0 +1,60 @@
+"""Simple piston reactor model."""
+
+from __future__ import annotations
+
+import cantera as ct
+import numpy as np
+from dataclasses import dataclass
+from typing import Optional
+
+from .batch import BatchResult
+
+
+@dataclass
+class PistonOptions:
+    a: float = 5e-4
+    phi: float = 2 * np.pi
+    heat_coeff: float = 0.3e3
+
+
+def run_piston(
+    gas: ct.Solution,
+    T0: float,
+    P0: float,
+    Y0: dict,
+    tf: float,
+    options: PistonOptions = PistonOptions(),
+    nsteps: int = 1000,
+) -> BatchResult:
+    """Integrate a variable-volume piston reactor."""
+
+    gas.TPY = T0, P0, Y0
+    reactor = ct.IdealGasReactor(gas, energy="on")
+    sim = ct.ReactorNet([reactor])
+
+    time = []
+    T = []
+    Y = []
+
+    dt = tf / nsteps
+    delay: Optional[float] = None
+    last_dTdt = 0.0
+
+    for _ in range(nsteps):
+        t = sim.time + dt
+        # update volume according to piston motion
+        v_dot = -options.a * options.phi * np.sin(options.phi * t)
+        reactor.volume += v_dot * dt
+        # heat loss
+        q = (400.0 - reactor.T) * options.heat_coeff
+        reactor.heat_transfer_coeff = q
+        sim.advance(t)
+        time.append(sim.time)
+        T.append(reactor.T)
+        Y.append(reactor.Y)
+        dTdt = (reactor.T - T[-2]) / dt if len(T) > 1 else 0.0
+        if last_dTdt > 0 and dTdt <= 0 and delay is None:
+            delay = time[-2]
+        last_dTdt = dTdt
+
+    return BatchResult(np.array(time), np.array(T), np.array(Y), ignition_delay=delay)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+cantera
+numpy
+scipy
+pandas
+matplotlib
+networkx
+torch
+torch_geometric

--- a/testing/pipeline.py
+++ b/testing/pipeline.py
@@ -1,0 +1,187 @@
+import csv
+import os
+from typing import Callable, List, Tuple, Sequence
+import numpy as np
+import cantera as ct
+from mechanism.loader import Mechanism
+from reactor.batch import BatchResult, run_constant_pressure
+from progress_variable import progress_variable, optimise_weights
+from metaheuristics import (
+    run_ga, GAOptions,
+    run_abc, ABCOptions,
+    run_bees, BeesOptions,
+    run_bnb, BnBOptions,
+)
+from visualizations import plot_convergence, plot_comparison
+from graph.construction import build_species_graph
+from gnn.models import train_dummy_gnn, predict_scores
+
+
+def pv_error(full: np.ndarray, red: np.ndarray) -> float:
+    return np.linalg.norm(full - red) / (np.linalg.norm(full) + 1e-12)
+
+
+def ignition_delay(time: np.ndarray, T: np.ndarray, Y: np.ndarray | None = None, species_idx: int | None = None) -> float:
+    """Return ignition delay based on temperature or species derivative.
+
+    If ``species_idx`` is provided, the ignition delay is taken from the peak of
+    ``dY[:, species_idx]/dt``; otherwise the peak of ``dT/dt`` is used.
+    """
+
+    if species_idx is not None and Y is not None:
+        deriv = np.gradient(Y[:, species_idx], time)
+    else:
+        deriv = np.gradient(T, time)
+    idx = int(np.argmax(deriv))
+    return float(time[idx])
+
+
+def evaluate_selection(
+    selection: np.ndarray,
+    base_mech: Mechanism,
+    Y0: dict,
+    tf: float,
+    full_res,
+    scores: np.ndarray | None = None,
+    weights: Sequence[float] | None = None,
+) -> float:
+    """Return fitness for a given species selection."""
+
+    keep = [base_mech.species_names[i] for i, bit in enumerate(selection) if bit]
+    mech = Mechanism(base_mech.file_path)
+    remove = [s for s in mech.species_names if s not in keep]
+    try:
+        if remove:
+            mech.remove_species(remove)
+        res = run_constant_pressure(mech.solution, full_res.temperature[0], ct.one_atm, Y0, tf, nsteps=len(full_res.time))
+    except Exception:
+        return -1e6
+    if weights is None:
+        weights = np.ones(full_res.mass_fractions.shape[1])
+    pv_full = progress_variable(full_res.mass_fractions, weights)
+    pv_red = progress_variable(res.mass_fractions, weights)
+    err = pv_error(pv_full, pv_red)
+    if scores is None:
+        size_penalty = selection.sum() / len(selection)
+    else:
+        size_penalty = (1 - selection) * scores
+        size_penalty = size_penalty.sum() / len(selection)
+    return -(err + 0.01 * float(size_penalty))
+
+
+def run_all_algorithms(
+    mech_path: str,
+    Y0: dict,
+    tf: float,
+    steps: int = 200,
+) -> Tuple[List[str], List[np.ndarray], List[List[float]], List[float], BatchResult, np.ndarray]:
+    """Run all metaheuristics on the given mechanism."""
+
+    mech = Mechanism(mech_path)
+    full = run_constant_pressure(mech.solution, 1000.0, ct.one_atm, Y0, tf, nsteps=steps)
+    genome_len = len(mech.species_names)
+
+    # optimise PV weights from the full solution
+    pv_ref = progress_variable(full.mass_fractions, np.ones(genome_len))
+    weights = optimise_weights(full.mass_fractions, pv_ref)
+
+    G = build_species_graph(mech.solution)
+    gnn_model = train_dummy_gnn(G, epochs=5)
+    scores_dict = predict_scores(gnn_model, G)
+    scores = np.array([scores_dict[s] for s in mech.species_names])
+
+    eval_fn = lambda sel: evaluate_selection(sel, mech, Y0, tf, full, scores, weights)
+
+    import time
+
+    runtimes: List[float] = []
+
+    t0 = time.perf_counter()
+    ga_sel, ga_hist = run_ga(genome_len, eval_fn, GAOptions(generations=5))
+    runtimes.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    abc_sel, abc_hist = run_abc(genome_len, eval_fn)
+    runtimes.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    bees_sel, bees_hist = run_bees(genome_len, eval_fn)
+    runtimes.append(time.perf_counter() - t0)
+
+    if genome_len <= 6:
+        t0 = time.perf_counter()
+        bnb_sel, bnb_hist = run_bnb(min(genome_len, 6), eval_fn, BnBOptions(max_size=6))
+        runtimes.append(time.perf_counter() - t0)
+    else:
+        bnb_sel, bnb_hist = np.ones(genome_len, dtype=int), []
+        runtimes.append(0.0)
+
+    names = ['GA', 'ABC', 'Bees', 'BnB']
+    solutions = [ga_sel, abc_sel, bees_sel, bnb_sel]
+    history = [ga_hist, abc_hist, bees_hist, bnb_hist]
+    return names, solutions, history, runtimes, full, weights
+
+
+def save_metrics(
+    names: List[str],
+    sols: List[np.ndarray],
+    runtimes: Sequence[float],
+    full_res: BatchResult,
+    mech: Mechanism,
+    Y0: dict,
+    tf: float,
+    out_dir: str,
+    weights: Sequence[float] | None = None,
+) -> None:
+    os.makedirs(out_dir, exist_ok=True)
+    metrics = []
+    if weights is None:
+        weights = np.ones(full_res.mass_fractions.shape[1])
+    pv_full = progress_variable(full_res.mass_fractions, weights)
+    full_delay = ignition_delay(full_res.time, full_res.temperature)
+    for name, sel, rt in zip(names, sols, runtimes):
+        keep = [mech.species_names[i] for i, b in enumerate(sel) if b]
+        red_mech = Mechanism(mech.file_path)
+        remove = [s for s in red_mech.species_names if s not in keep]
+        try:
+            if remove:
+                red_mech.remove_species(remove)
+            res = run_constant_pressure(red_mech.solution, 1000.0, ct.one_atm, Y0, tf, nsteps=len(full_res.time))
+            pv_red = progress_variable(res.mass_fractions, weights)
+            err = pv_error(pv_full, pv_red)
+            delay = ignition_delay(res.time, res.temperature)
+            size_red = 1 - sel.sum() / len(sel)
+            metrics.append([name, err, abs(delay - full_delay)/full_delay, size_red, rt])
+        except Exception:
+            metrics.append([name, 1.0, 1.0, 0.0, rt])
+    with open(os.path.join(out_dir, 'metrics.csv'), 'w', newline='') as f:
+        writer = csv.writer(f)
+        writer.writerow(['algorithm', 'pv_error', 'ignition_delay_error', 'size_reduction', 'runtime'])
+        writer.writerows(metrics)
+
+
+import matplotlib.pyplot as plt
+
+def plot_profiles(full_res, mech: Mechanism, Y0: dict, tf: float, out_dir: str):
+    key_species = ['CH4', 'O2', 'CO2']
+    plt.figure()
+    for sp in key_species:
+        if sp in mech.species_names:
+            idx = mech.species_names.index(sp)
+            plt.plot(full_res.time, full_res.mass_fractions[:, idx], label=sp)
+    plt.xlabel('Time [s]')
+    plt.ylabel('Mass Fraction')
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(os.path.join(out_dir, 'profiles.png'))
+    plt.close()
+
+def full_pipeline(mech_path: str, out_dir: str, steps: int = 200):
+    Y0 = {'CH4':0.5, 'O2':1.0, 'N2':3.76}
+    tf = 0.02
+    names, solutions, history, runtimes, full, weights = run_all_algorithms(mech_path, Y0, tf, steps)
+    mech = Mechanism(mech_path)
+    save_metrics(names, solutions, runtimes, full, mech, Y0, tf, out_dir, weights)
+    plot_profiles(full, mech, Y0, tf, out_dir)
+    plot_convergence(history, names, out_dir)
+    plot_comparison(os.path.join(out_dir, 'metrics.csv'), out_dir)

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -1,0 +1,13 @@
+import argparse
+from testing.pipeline import full_pipeline
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--mechanism', required=True)
+    parser.add_argument('--out', default='results')
+    args = parser.parse_args()
+    full_pipeline(args.mechanism, args.out, steps=50)
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_ga.py
+++ b/tests/test_ga.py
@@ -1,0 +1,10 @@
+from metaheuristics.ga import run_ga, GAOptions
+import numpy as np
+
+def simple_eval(genome: np.ndarray) -> float:
+    return genome.sum()
+
+def test_ga_runs():
+    best, hist = run_ga(5, simple_eval, GAOptions(population_size=4, generations=5))
+    assert best.sum() <= 5
+    assert len(hist) == 5

--- a/tests/test_mechanism.py
+++ b/tests/test_mechanism.py
@@ -1,0 +1,5 @@
+from mechanism import Mechanism
+
+def test_load():
+    mech = Mechanism('data/gri30.yaml')
+    assert 'CH4' in mech.species_names

--- a/tests/test_metaheuristics.py
+++ b/tests/test_metaheuristics.py
@@ -1,0 +1,24 @@
+import numpy as np
+from metaheuristics import run_abc, run_bees, run_bnb
+
+
+def simple_eval(g: np.ndarray) -> float:
+    return g.sum()
+
+
+def test_abc():
+    best, hist = run_abc(4, simple_eval)
+    assert best.sum() <= 4
+    assert len(hist) > 0
+
+
+def test_bees():
+    best, hist = run_bees(4, simple_eval)
+    assert best.sum() <= 4
+    assert len(hist) > 0
+
+
+def test_bnb():
+    best, hist = run_bnb(3, simple_eval)
+    assert best.sum() <= 3
+    assert len(hist) > 0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,10 @@
+from metrics import l2_distance
+import numpy as np
+
+
+def test_l2_distance():
+    Y1 = np.zeros((3,2))
+    Y2 = np.ones((3,2))
+    t = np.array([0.0, 0.5, 1.0])
+    d = l2_distance(Y1, Y2, t)
+    assert d > 0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,15 @@
+import pytest
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+
+@pytest.mark.skipif(torch is None, reason="requires torch")
+def test_pipeline_runs(tmp_path):
+    from testing.pipeline import full_pipeline
+    out = tmp_path / "out"
+    full_pipeline("data/gri30.yaml", str(out), steps=10)
+    assert (out / "metrics.csv").exists()
+    assert (out / "convergence.png").exists()

--- a/tests/test_progress_var.py
+++ b/tests/test_progress_var.py
@@ -1,0 +1,9 @@
+from progress_variable import progress_variable, optimise_weights
+import numpy as np
+
+
+def test_optimise_weights():
+    Y = np.random.rand(5, 3)
+    pv_ref = progress_variable(Y, [1, 0, 1])
+    w = optimise_weights(Y, pv_ref)
+    assert len(w) == 3

--- a/tests/test_reactors.py
+++ b/tests/test_reactors.py
@@ -1,0 +1,8 @@
+import cantera as ct
+from reactor.batch import run_constant_volume
+
+
+def test_constant_volume_runs():
+    gas = ct.Solution('gri30.yaml')
+    res = run_constant_volume(gas, 1000.0, ct.one_atm, {'CH4':0.5, 'O2':1.0, 'N2':3.76}, 0.001, nsteps=5)
+    assert len(res.time) == 5

--- a/timescales.py
+++ b/timescales.py
@@ -1,0 +1,25 @@
+"""Timescale computations from the system Jacobian."""
+
+from __future__ import annotations
+
+import cantera as ct
+import numpy as np
+
+
+def species_timescales(gas: ct.Solution) -> np.ndarray:
+    """Return characteristic time scales from the Jacobian eigenvalues."""
+    J = gas.jacobian_full
+    eig = np.linalg.eigvals(J)
+    with np.errstate(divide="ignore"):
+        tau = 1 / np.abs(eig)
+    return np.sort(np.real(tau))
+
+
+def progress_variable_timescale(pv: np.ndarray, time: np.ndarray) -> float:
+    """Estimate PV timescale as the time for PV to rise from 10% to 90%."""
+    pv_norm = (pv - pv.min()) / (pv.max() - pv.min() + 1e-12)
+    i1 = np.searchsorted(pv_norm, 0.1)
+    i2 = np.searchsorted(pv_norm, 0.9)
+    if i2 <= i1:
+        return 0.0
+    return float(time[i2] - time[i1])

--- a/visualizations/__init__.py
+++ b/visualizations/__init__.py
@@ -1,0 +1,73 @@
+"""Plotting utilities for metaheuristic convergence and comparison charts."""
+
+from __future__ import annotations
+
+import os
+from typing import Sequence
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+def plot_convergence(histories: Sequence[Sequence[float]], names: Sequence[str], out_dir: str) -> None:
+    """Plot fitness convergence for each algorithm.
+
+    Parameters
+    ----------
+    histories:
+        Sequence of fitness histories (one list per algorithm).
+    names:
+        Algorithm names in the same order as ``histories``.
+    out_dir:
+        Directory to save plots. PNG and PDF are saved with the name
+        ``convergence``.
+    """
+    os.makedirs(out_dir, exist_ok=True)
+    plt.figure()
+    for hist, name in zip(histories, names):
+        if len(hist) == 0:
+            continue
+        plt.plot(range(len(hist)), hist, label=name)
+    plt.xlabel("Iteration")
+    plt.ylabel("Fitness")
+    plt.legend()
+    plt.tight_layout()
+    png = os.path.join(out_dir, "convergence.png")
+    pdf = os.path.join(out_dir, "convergence.pdf")
+    plt.savefig(png)
+    plt.savefig(pdf)
+    plt.close()
+
+
+def plot_comparison(metrics_csv: str, out_dir: str) -> None:
+    """Create comparison charts for reduction performance.
+
+    Parameters
+    ----------
+    metrics_csv:
+        Path to CSV file with columns ``algorithm``, ``pv_error``, ``ignition_delay_error``,
+        ``size_reduction`` and ``runtime``.
+    out_dir:
+        Directory to save plots. PNG and PDF are saved with the base name
+        ``comparison``.
+    """
+    df = pd.read_csv(metrics_csv)
+    os.makedirs(out_dir, exist_ok=True)
+    fig, axes = plt.subplots(3, 1, figsize=(6, 9))
+
+    axes[0].bar(df["algorithm"], df["size_reduction"])
+    axes[0].set_ylabel("Size Reduction")
+
+    axes[1].bar(df["algorithm"], df["runtime"])
+    axes[1].set_ylabel("Runtime [s]")
+
+    axes[2].bar(df["algorithm"], df["pv_error"])
+    axes[2].set_ylabel("PV Error")
+    axes[2].set_xlabel("Algorithm")
+
+    fig.tight_layout()
+    png = os.path.join(out_dir, "comparison.png")
+    pdf = os.path.join(out_dir, "comparison.pdf")
+    fig.savefig(png)
+    fig.savefig(pdf)
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- implement visualization helpers for convergence curves and comparison charts
- return GA history and runtimes for all metaheuristics
- record runtimes in metrics CSV
- plot convergence and comparison charts in testing pipeline
- document new plots in README

## Testing
- `pytest -q`
- `python -m testing.run_tests --mechanism data/gri30.yaml --out results` *(fails: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_686545a82a648328a19b82ac751d7f06