### PR TITLE
Add plotting and CLI utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,30 @@ python -m testing.run_tests --mechanism data/gri30.yaml --out results
 
 This command executes all metaheuristics, compares reduced mechanisms to the full one and stores metrics and plots in the `results` folder.
 
+Example output files in ``results/``:
+
+```
+results/
+    metrics.csv
+    pv_error.csv
+    ignition_delay.csv
+    species_retained.csv
+    ga_fitness.csv
+    abc_fitness.csv
+    bees_fitness.csv
+    profiles.png / .pdf
+    convergence.png / .pdf
+    ignition_delay.png / .pdf
+    pv_error.png / .pdf
+```
+
+Each CSV contains numeric data that can be imported into other tools for further analysis.
+
+The command accepts two arguments:
+
+- ``--mechanism`` – path to the Cantera YAML mechanism.
+- ``--out`` – directory where all plots and CSVs are written.
+
 ## Installation
 
 Required packages are listed below.  Install with `pip`:

--- a/metaheuristics/ga.py
+++ b/metaheuristics/ga.py
@@ -1,6 +1,6 @@
 import numpy as np
 from dataclasses import dataclass
-from typing import Callable, List
+from typing import Callable, Iterable, List, Tuple
 
 @dataclass
 class GAOptions:
@@ -39,16 +39,45 @@ def mutate(population: np.ndarray, rate: float) -> np.ndarray:
     return population
 
 
-def run_ga(genome_length: int, eval_fn: Callable[[np.ndarray], float], options: GAOptions = GAOptions()) -> np.ndarray:
+def run_ga(
+    genome_length: int,
+    eval_fn: Callable[[np.ndarray], float],
+    options: GAOptions = GAOptions(),
+    return_history: bool = False,
+) -> np.ndarray | Tuple[np.ndarray, List[float]]:
+    """Run a simple genetic algorithm.
+
+    Parameters
+    ----------
+    genome_length:
+        Length of the binary genome.
+    eval_fn:
+        Fitness evaluation function returning a scalar value.
+    options:
+        Control parameters for the GA.
+    return_history:
+        If ``True`` the function also returns a list of best scores per
+        generation.
+
+    Returns
+    -------
+    np.ndarray or Tuple[np.ndarray, List[float]]
+        The best genome found and optionally the score history.
+    """
+
     pop = initialize_population(options.population_size, genome_length)
     best = pop[0]
     best_score = -np.inf
+    history: List[float] = []
     for _ in range(options.generations):
         scores = fitness(pop, eval_fn)
         if scores.max() > best_score:
-            best_score = scores.max()
+            best_score = float(scores.max())
             best = pop[scores.argmax()]
+        history.append(best_score)
         pop = selection(pop, scores)
         pop = crossover(pop, options.crossover_rate)
         pop = mutate(pop, options.mutation_rate)
+    if return_history:
+        return best, history
     return best

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -1,11 +1,16 @@
+"""CLI entry point for running the reduction testing pipeline."""
+
 import argparse
+
 from testing.pipeline import full_pipeline
 
 
 def main():
+    """Parse command line arguments and run the pipeline."""
+
     parser = argparse.ArgumentParser()
-    parser.add_argument('--mechanism', required=True)
-    parser.add_argument('--out', default='results')
+    parser.add_argument("--mechanism", required=True, help="Path to mechanism YAML file")
+    parser.add_argument("--out", default="results", help="Output directory")
     args = parser.parse_args()
     full_pipeline(args.mechanism, args.out, steps=50)
 

--- a/visualizations/__init__.py
+++ b/visualizations/__init__.py
@@ -1,0 +1,13 @@
+from .plots import (
+    plot_mole_fraction,
+    plot_ignition_delays,
+    plot_convergence,
+    plot_pv_errors,
+)
+
+__all__ = [
+    "plot_mole_fraction",
+    "plot_ignition_delays",
+    "plot_convergence",
+    "plot_pv_errors",
+]

--- a/visualizations/plots.py
+++ b/visualizations/plots.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Plotting utilities for mechanism reduction results."""
+
+import os
+from typing import Sequence, Iterable
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def _save(fig: plt.Figure, out_base: str) -> None:
+    """Save figure as PNG and PDF."""
+    os.makedirs(os.path.dirname(out_base), exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(out_base + ".png")
+    fig.savefig(out_base + ".pdf")
+    plt.close(fig)
+
+
+def plot_mole_fraction(
+    time_full: np.ndarray,
+    y_full: np.ndarray,
+    time_red: np.ndarray,
+    y_red: np.ndarray,
+    species: Sequence[str],
+    out_base: str,
+) -> None:
+    """Plot mole-fraction profiles for selected species."""
+    fig, ax = plt.subplots()
+    for i, sp in enumerate(species):
+        ax.plot(time_full, y_full[:, i], label=f"{sp} full")
+        ax.plot(time_red, y_red[:, i], "--", label=f"{sp} red")
+    ax.set_xlabel("Time [s]")
+    ax.set_ylabel("Mole fraction")
+    ax.legend()
+    _save(fig, out_base)
+
+
+def plot_ignition_delays(delays: Sequence[float], labels: Sequence[str], out_base: str) -> None:
+    """Bar chart of ignition delays."""
+    fig, ax = plt.subplots()
+    ax.bar(labels, delays)
+    ax.set_ylabel("Ignition delay [s]")
+    _save(fig, out_base)
+
+
+def plot_convergence(histories: Sequence[Iterable[float]], labels: Sequence[str], out_base: str) -> None:
+    """Plot convergence histories for metaheuristics."""
+    fig, ax = plt.subplots()
+    for hist, label in zip(histories, labels):
+        if hist:
+            ax.plot(list(range(len(hist))), list(hist), label=label)
+    ax.set_xlabel("Iteration")
+    ax.set_ylabel("Best fitness")
+    ax.legend()
+    _save(fig, out_base)
+
+
+def plot_pv_errors(errors: Sequence[float], labels: Sequence[str], out_base: str) -> None:
+    """Bar chart of progress variable errors."""
+    fig, ax = plt.subplots()
+    ax.bar(labels, errors)
+    ax.set_ylabel("PV error")
+    _save(fig, out_base)


### PR DESCRIPTION
## Summary
- extend GA with optional history output
- add visualization helpers for mechanism reduction metrics
- overhaul pipeline to save CSV metrics and produce plots
- document CLI and output files in README
- expose CLI entry point `python -m testing.run_tests`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865407fbdf483288845aacd413173f2