### PR TITLE
Enable reactive GA reduction with GNN guidance

### DIFF
--- a/metaheuristics/abc.py
+++ b/metaheuristics/abc.py
@@ -1,5 +1,0 @@
-"""Deprecated module for the Artificial Bee Colony algorithm.
-
-The implementation was removed during repository cleanup.  The file is kept
-as a placeholder to avoid import errors but provides no functionality.
-"""

--- a/metaheuristics/bees.py
+++ b/metaheuristics/bees.py
@@ -1,5 +1,0 @@
-"""Deprecated module for the Bees algorithm.
-
-The implementation has been intentionally removed; this file acts only as a
-placeholder.
-"""

--- a/metaheuristics/bnb.py
+++ b/metaheuristics/bnb.py
@@ -1,3 +1,0 @@
-"""Deprecated module for the Branch-and-Bound search.
-
-Removed during cleanup; retained only as a placeholder."""

--- a/reactor/batch.py
+++ b/reactor/batch.py
@@ -13,20 +13,59 @@ class BatchResult:
     ignition_delay: Optional[float] = None
 
 
-def run_constant_pressure(gas: ct.Solution, T0: float, P0: float, Y0: dict, tf: float, nsteps: int = 1000) -> BatchResult:
-    gas.TPY = T0, P0, Y0
-    reactor = ct.IdealGasConstPressureReactor(gas)
+def run_constant_pressure(
+    gas: ct.Solution,
+    T0: float,
+    P0: float,
+    X0: dict,
+    tf: float,
+    nsteps: int = 1000,
+    detect_ignition: bool = True,
+) -> BatchResult:
+    """Integrate an adiabatic constant-pressure reactor.
+
+    Parameters
+    ----------
+    gas:
+        Cantera ``Solution`` object representing the mechanism.
+    T0, P0:
+        Initial temperature and pressure.
+    X0:
+        Initial composition specified as mole fractions. Using mole fractions
+        avoids accidental non-reactive mixtures when large values are passed
+        for stoichiometric ratios.
+    tf, nsteps:
+        Final time and number of integration steps.
+    detect_ignition:
+        If ``True`` the ignition delay is estimated from the temperature
+        derivative.
+    """
+
+    # Use TPX to ensure the provided composition is interpreted as mole
+    # fractions.  Previous versions used TPY which silently normalised the
+    # numbers as mass fractions and resulted in nearly non-reactive mixtures.
+    gas.TPX = T0, P0, X0
+    reactor = ct.IdealGasConstPressureReactor(gas, energy="on")
     sim = ct.ReactorNet([reactor])
-    time = []
-    T = []
-    Y = []
-    dt = tf/nsteps
+
+    time: list[float] = []
+    T: list[float] = []
+    Y: list[np.ndarray] = []
+    delay = None
+    last_dTdt = 0.0
+    dt = tf / nsteps
     for _ in range(nsteps):
         sim.advance(sim.time + dt)
         time.append(sim.time)
         T.append(reactor.T)
         Y.append(reactor.Y)
-    return BatchResult(np.array(time), np.array(T), np.array(Y))
+        if detect_ignition:
+            dTdt = (reactor.T - T[-2]) / dt if len(T) > 1 else 0.0
+            if last_dTdt > 0 and dTdt <= 0 and delay is None:
+                delay = time[-2]
+            last_dTdt = dTdt
+
+    return BatchResult(np.array(time), np.array(T), np.array(Y), ignition_delay=delay)
 
 
 def run_constant_volume(
@@ -40,8 +79,10 @@ def run_constant_volume(
 ) -> BatchResult:
     """Integrate a constant-volume adiabatic reactor."""
 
-    gas.TPY = T0, P0, Y0
-    reactor = ct.IdealGasReactor(gas)
+    # As with the constant-pressure case, interpret composition as mole
+    # fractions to avoid near-inert mixtures when using stoichiometric ratios.
+    gas.TPX = T0, P0, Y0
+    reactor = ct.IdealGasReactor(gas, energy="on")
     sim = ct.ReactorNet([reactor])
     time = []
     T = []


### PR DESCRIPTION
## Summary
- Ensure Cantera batch reactor ignites by using mole-fraction initialization, enabling energy, and tracking ignition delay.
- Align progress-variable computations across full and reduced mechanisms via species name mapping.
- Improve GA: add minimum-species constraint, robust selection, optional genome mask, and enhanced debug output.
- Seed GA using top 30% GNN-scored species and apply fitness `-pv_error - 10*delay_diff - size_penalty` with flat-profile penalties.
- Remove unused ABC, Bees, and BnB metaheuristics, keeping only GA + GNN modules.

## Testing
- `python -m testing.run_tests --out results --steps 500 --tf 1.0`


------
https://chatgpt.com/codex/tasks/task_e_68938ddb4c888328961263fc7b931c2b