### PR TITLE
Improve PFR robustness and align evaluation grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Our fully functional **Prototype v1** performs end-to-end reduction, evaluates t
 ## 🚀 How to Run the Pipeline
 
 ```bash
-python -m testing.run_tests --mechanism data/gri30.yaml --out results --steps 200 --tf 5.0
+python -m testing.run_tests --mechanism data/gri30.yaml --out results --steps 200 --tf 5.0 --fitness-mode standard
 ````
 
 * `--mechanism`: Path to the full chemical mechanism file (default: `data/gri30.yaml`)
@@ -56,14 +56,14 @@ emits additional artefacts:
 python -m testing.run_tests \
   --mode 1d --mechanism data/gri30.yaml --out results/pox_nominal \
   --phi 0.7 --T0 700 --p0 1.0e6 --L 0.8 --D 0.05 --mdot 0.12 --U 0.0 \
-  --steps 400 --fitness-mode threshold --tol-pv 0.05 --tol-delay 0.05 --tol-timescale 0.05 --tol-resid 0.05
+  --steps 400 --fitness-mode threshold --tol-pv 0.15 --tol-delay 0.15 --tol-timescale 1.5 --tol-resid 0.05
 
 # Plasma surrogate (torch heating to 1500 K with radical seeding)
 python -m testing.run_tests \
   --mode 1d --mechanism data/gri30.yaml --out results/plasma_demo \
   --phi 1.0 --T0 400 --p0 2.0e5 --L 0.6 --D 0.04 --mdot 0.08 \
   --plasma-length 0.1 --T-plasma-out 1500 --radical-seed "H:0.005,OH:0.002" \
-  --steps 400 --fitness-mode threshold --tol-pv 0.05 --tol-delay 0.05 --tol-timescale 0.05 --tol-resid 0.05
+  --steps 400 --fitness-mode threshold --tol-pv 0.15 --tol-delay 0.15 --tol-timescale 1.5 --tol-resid 0.05
 ```
 
 Both commands populate the additional PFR CSVs, plots, and LaTeX tables described above while keeping the GA–GNN reduction

--- a/visualizations/plots.py
+++ b/visualizations/plots.py
@@ -319,8 +319,16 @@ def plot_axial_overlays(cases: Sequence[dict], species: Sequence[str], out_base:
         x = np.asarray(data.get("x", []), dtype=float)
         if x.size == 0:
             continue
-        axes[0].plot(x, data.get("T_full", []), label=f"{data['id']} full")
-        axes[0].plot(x, data.get("T_red", []), linestyle="--", label=f"{data['id']} red")
+        xu, idx = np.unique(x, return_index=True)
+        T_full = np.asarray(data.get("T_full", []), dtype=float)
+        T_red = np.asarray(data.get("T_red", []), dtype=float)
+        valid = (idx < T_full.size) & (idx < T_red.size)
+        if not np.any(valid):
+            continue
+        idx_valid = idx[valid]
+        xu_valid = xu[valid]
+        axes[0].plot(xu_valid, T_full[idx_valid], label=f"{data['id']} full")
+        axes[0].plot(xu_valid, T_red[idx_valid], linestyle="--", label=f"{data['id']} red")
         axes[0].axvline(data.get("ign_full", np.nan), color="0.6", ls=":", alpha=0.5)
         axes[0].axvline(data.get("ign_red", np.nan), color="0.3", ls="--", alpha=0.5)
 
@@ -336,8 +344,32 @@ def plot_axial_overlays(cases: Sequence[dict], species: Sequence[str], out_base:
             spec = data.get("species", {}).get(sp)
             if not spec:
                 continue
-            axes[1].plot(data["x"], spec[0], color=color, alpha=0.8, label=f"{sp} {data['id']} full")
-            axes[1].plot(data["x"], spec[1], color=color, linestyle="--", alpha=0.6, label=f"{sp} {data['id']} red")
+            x = np.asarray(data.get("x", []), dtype=float)
+            if x.size == 0:
+                continue
+            xu, idx = np.unique(x, return_index=True)
+            full_arr = np.asarray(spec[0], dtype=float)
+            red_arr = np.asarray(spec[1], dtype=float)
+            valid = (idx < full_arr.size) & (idx < red_arr.size)
+            if not np.any(valid):
+                continue
+            idx_valid = idx[valid]
+            xu_valid = xu[valid]
+            axes[1].plot(
+                xu_valid,
+                full_arr[idx_valid],
+                color=color,
+                alpha=0.8,
+                label=f"{sp} {data['id']} full",
+            )
+            axes[1].plot(
+                xu_valid,
+                red_arr[idx_valid],
+                color=color,
+                linestyle="--",
+                alpha=0.6,
+                label=f"{sp} {data['id']} red",
+            )
 
     axes[1].set_xlabel("Axial coordinate [m]")
     axes[1].set_ylabel("Mass fraction")


### PR DESCRIPTION
## Summary
- enforce monotone axial grids in the PFR post-processing and compute the temperature gradient with a guarded finite difference
- add reusable interpolation/RMS helpers so PV, SPTS and PV error scoring operate on the reference grid and emit GNN scores into each run's out directory
- harden timescale utilities and plotting overlays against duplicate coordinates and document the recommended threshold settings for 1-D runs

## Testing
- python -m testing.run_tests --mechanism data/gri30.yaml --out results_0d_quick --steps 300 --tf 7e-3 --log-times --phi 0.90 --T0 1450 --p0 101325 --generations 5 --population 10 --mutation 0.22 --alpha 0.8 --tf-short 1.5e-3 --steps-short 120 --fitness-mode threshold --tol-pv 0.10 --tol-delay 0.10 --tol-timescale 0.15 --tol-resid 0.03
- python -m testing.run_tests --mode 1d --mechanism data/gri30.yaml --out results_1d_nominal --steps 600 --phi 1.65 --T0 700 --p0 5e5 --L 1.0 --D 0.05 --mdot 0.05 --diluent OXY --U 0.0 --plasma-length 0.05 --T-plasma-out 1450 --generations 10 --population 12 --mutation 0.22 --fitness-mode threshold --tol-pv 0.15 --tol-delay 0.15 --tol-timescale 1.5 --tol-resid 0.05 --envelopes envelopes.json

------
https://chatgpt.com/codex/tasks/task_e_68d422fe635c8328a56bdcbbba65d132