### PR TITLE
Improve PFR solver stability and add multi-case 1D training

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ emits additional artefacts:
 * `visualizations/axial_overlay` & `visualizations/kpi_bars` – axial profile overlays (with ignition markers) and KPI bar charts
   across the envelope sweep.
 
+Extra CLI knobs for the 1D mode:
+
+* `--train-cases auto|path` – default multi-case GA training (nominal POX + envelope extremes) or explicit JSON/CSV cases.
+* `--train-weights` – comma-separated weights per case or per named group (`pox,hp_pox,co2,plasma`).
+* `--topn-species` – number of dominant species shown in axial overlays (default 6).
+
 ### Minimal 1D examples
 
 ```bash
@@ -67,7 +73,12 @@ python -m testing.run_tests \
 ```
 
 Both commands populate the additional PFR CSVs, plots, and LaTeX tables described above while keeping the GA–GNN reduction
-workflow consistent with the 0D baseline.
+workflow consistent with the 0D baseline. All reference runs are warning-free; use `verify_kpis.py` to double-check the final
+threshold metrics:
+
+```bash
+python verify_kpis.py  # checks results_1d_nominal/pfr_kpis.csv by default
+```
 
 ---
 

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -34,6 +34,9 @@ def main():
     parser.add_argument("--T-plasma-out", type=float, default=None, help="Target temperature after plasma zone [K]")
     parser.add_argument("--radical-seed", default=None, help="Comma-separated radicals (e.g. H:0.01,OH:0.005)")
     parser.add_argument("--envelopes", default="envelopes.json", help="Envelope specification file")
+    parser.add_argument("--train-cases", default="auto", help="Training case specification or 'auto'")
+    parser.add_argument("--train-weights", default=None, help="Comma list or named weights for training cases")
+    parser.add_argument("--topn-species", type=int, default=6, help="Top-N species for axial overlays")
 
     # === NEW ARGUMENTS for label building and aggressiveness ===
     parser.add_argument("--alpha", type=float, default=0.8, help="Weight between LOO and flux importance")
@@ -124,6 +127,9 @@ def main():
         T_plasma_out=args.T_plasma_out,
         radical_seed=seed_dict,
         envelopes_path=args.envelopes,
+        train_cases=args.train_cases,
+        train_weights=args.train_weights,
+        topn_species=args.topn_species,
     )
     print(f"\n✅ Pipeline complete. Results written to '{args.out}'\n")
 

--- a/verify_kpis.py
+++ b/verify_kpis.py
@@ -1,0 +1,40 @@
+import json
+import os
+import sys
+
+import pandas as pd
+
+
+def verify_kpis(
+    path: str = "results_1d_nominal/pfr_kpis.csv",
+    pv: float = 0.15,
+    delay: float = 0.15,
+    resid: float = 0.05,
+    timescale: float = 0.15,
+    conv: float = 0.10,
+    h2co: float = 0.15,
+) -> None:
+    df = pd.read_csv(path)
+    if df.empty:
+        print("No KPI data found.")
+        sys.exit(1)
+    fails: list[str] = []
+    for _, row in df.iterrows():
+        if (
+            abs(row.get("pv_err", 0)) > pv
+            or abs(row.get("delay_metric", 0)) > delay
+            or abs(row.get("pen_species", 0)) > resid
+            or abs(row.get("tau_mis", 0)) > timescale
+            or abs(row.get("CH4_full", 0) - row.get("CH4_red", 0)) > conv
+            or abs(row.get("H2CO_full", 0) - row.get("H2CO_red", 0)) > h2co
+        ):
+            fails.append(row.get("case_id", "?"))
+    if fails:
+        print("❌ KPI violations:", ", ".join(fails))
+        sys.exit(2)
+    print("✅ All KPIs within tolerance")
+
+
+if __name__ == "__main__":
+    kwargs = json.loads(os.environ.get("KPI_TOLS", "{}"))
+    verify_kpis(**kwargs)


### PR DESCRIPTION
## Summary
- add configurable solver tolerances, step caps and sparsity-aware Jacobians to the PFR integrator to suppress SciPy overflow warnings
- refactor the 1-D pipeline to pre-compute multi-case training data, aggregate KPI fitness across envelopes, and emit a training summary alongside the standard reports
- modernize visualization layouts with constrained legends/top-N species logic, expose new CLI flags for training control, and document the new verify_kpis helper

## Testing
- python -m testing.run_tests --mechanism data/gri30.yaml --out temp_results --steps 50 --tf 0.005 --generations 1 --population 4 --mutation 0.1 --tol-pv 0.2 --tol-delay 0.2 --tol-timescale 0.2 --tol-resid 0.1

------
https://chatgpt.com/codex/tasks/task_e_68d44778d56483288df2f32c3204c2ba