### PR TITLE
Improve GA reduction robustness and reporting

### DIFF
--- a/hp_pox/plots.py
+++ b/hp_pox/plots.py
@@ -8,6 +8,17 @@ from typing import Mapping, Sequence
 import matplotlib.pyplot as plt
 import numpy as np
 
+plt.rcParams["axes.prop_cycle"] = plt.cycler(
+    color=[
+        "#1f77b4",
+        "#ff7f0e",
+        "#2ca02c",
+        "#d62728",
+        "#9467bd",
+        "#8c564b",
+    ]
+)
+
 
 def plot_profile_overlay(
     positions: np.ndarray,
@@ -28,7 +39,9 @@ def plot_profile_overlay(
     ax[0].set_ylabel("Temperature (K)")
     ax[0].legend()
     if ignition_full is not None:
-        ax[0].axvline(ignition_full, color="tab:red", linestyle=":", label="ignition full")
+        ax[0].axvline(
+            ignition_full, color="tab:red", linestyle=":", label="ignition full"
+        )
     if ignition_reduced is not None:
         ax[0].axvline(
             ignition_reduced,
@@ -60,6 +73,32 @@ def plot_profile_overlay(
     plt.close(fig)
 
 
+def plot_progress_variable_overlay(
+    positions_full: np.ndarray,
+    pv_full: np.ndarray,
+    positions_reduced: np.ndarray,
+    pv_reduced: np.ndarray,
+    out_path: Path,
+) -> None:
+    fig, ax = plt.subplots(figsize=(6, 4), dpi=150)
+    ax.plot(positions_full, pv_full, label="full", linewidth=2)
+    ax.plot(
+        positions_reduced,
+        pv_reduced,
+        linestyle="--",
+        marker="o",
+        markersize=3,
+        label="reduced",
+    )
+    ax.set_xlabel("Axial position (m)")
+    ax.set_ylabel("Progress variable")
+    ax.grid(True, alpha=0.3)
+    ax.legend(frameon=False)
+    fig.tight_layout()
+    fig.savefig(out_path)
+    plt.close(fig)
+
+
 def plot_profile_residuals(
     positions: np.ndarray,
     residuals: Mapping[str, np.ndarray],
@@ -78,6 +117,27 @@ def plot_profile_residuals(
     plt.close(fig)
 
 
+def plot_timescales_overlay(
+    time_full: np.ndarray,
+    scales_full: Mapping[str, np.ndarray],
+    time_reduced: np.ndarray,
+    scales_reduced: Mapping[str, np.ndarray],
+    out_path: Path,
+) -> None:
+    fig, ax = plt.subplots(figsize=(6, 4), dpi=150)
+    for name, series in scales_full.items():
+        ax.semilogy(time_full, series, label=f"{name} (full)")
+    for name, series in scales_reduced.items():
+        ax.semilogy(time_reduced, series, linestyle="--", label=f"{name} (reduced)")
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel("Timescale (s)")
+    ax.grid(True, which="both", alpha=0.3)
+    ax.legend(frameon=False, fontsize=8, ncol=2)
+    fig.tight_layout()
+    fig.savefig(out_path)
+    plt.close(fig)
+
+
 def plot_ignition_positions(
     full_position: float | None,
     reduced_position: float | None,
@@ -86,8 +146,10 @@ def plot_ignition_positions(
 ) -> None:
     fig, ax = plt.subplots(figsize=(5, 3), dpi=150)
     xpos = [0, 1]
-    ypos = [full_position if full_position is not None else np.nan,
-            reduced_position if reduced_position is not None else np.nan]
+    ypos = [
+        full_position if full_position is not None else np.nan,
+        reduced_position if reduced_position is not None else np.nan,
+    ]
     ax.scatter(xpos, ypos, s=80)
     ax.set_xticks(xpos)
     ax.set_xticklabels(labels)

--- a/hp_pox/reduction_train.py
+++ b/hp_pox/reduction_train.py
@@ -9,8 +9,12 @@ from .reduction import GAGNNReducer, ReductionConfig
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Train a reduced mechanism using GA+GNN.")
-    parser.add_argument("--mechanism", required=True, help="Path to the full mechanism YAML file.")
+    parser = argparse.ArgumentParser(
+        description="Train a reduced mechanism using GA+GNN."
+    )
+    parser.add_argument(
+        "--mechanism", required=True, help="Path to the full mechanism YAML file."
+    )
     parser.add_argument(
         "--cases-1d",
         nargs="*",
@@ -21,9 +25,21 @@ def parse_args() -> argparse.Namespace:
         nargs="*",
         help="Optional zero-dimensional cases for PV/IDT penalties (not yet implemented).",
     )
-    parser.add_argument("--gnn-seed", dest="gnn_seed", help="CSV file with GNN scores for seeding.")
-    parser.add_argument("--keep-core", dest="keep_core", action="store_true", help="Keep core species fixed.")
-    parser.add_argument("--no-keep-core", dest="keep_core", action="store_false", help="Allow GA to drop core species.")
+    parser.add_argument(
+        "--gnn-seed", dest="gnn_seed", help="CSV file with GNN scores for seeding."
+    )
+    parser.add_argument(
+        "--keep-core",
+        dest="keep_core",
+        action="store_true",
+        help="Keep core species fixed.",
+    )
+    parser.add_argument(
+        "--no-keep-core",
+        dest="keep_core",
+        action="store_false",
+        help="Allow GA to drop core species.",
+    )
     parser.set_defaults(keep_core=None)
     defaults = ReductionConfig.__dataclass_fields__
     parser.add_argument(
@@ -45,16 +61,27 @@ def parse_args() -> argparse.Namespace:
         help="Elitism setting for GA.",
     )
     parser.add_argument("--seed", type=int, help="Random seed for reproducibility.")
-    parser.add_argument("--out", type=Path, default=ReductionConfig.output_dir, help="Output directory.")
+    parser.add_argument(
+        "--out", type=Path, default=ReductionConfig.output_dir, help="Output directory."
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
     defaults = ReductionConfig.__dataclass_fields__
-    cases_1d = tuple(args.cases_1d) if args.cases_1d else defaults["cases_1d"].default
+    if args.cases_1d:
+        cases_1d = tuple(case.split(":", 1)[0] for case in args.cases_1d)
+    else:
+        cases_1d = defaults["cases_1d"].default
     cases_0d = tuple(args.cases_0d) if args.cases_0d else defaults["cases_0d"].default
-    keep_core = args.keep_core if args.keep_core is not None else defaults["keep_core"].default
+    if args.cases_0d:
+        print(
+            "Notice: 0-D training cases are not yet supported and will be ignored.",
+        )
+    keep_core = (
+        args.keep_core if args.keep_core is not None else defaults["keep_core"].default
+    )
     config = ReductionConfig(
         mechanism=args.mechanism,
         cases_1d=cases_1d,
@@ -70,7 +97,9 @@ def main() -> None:
     reducer = GAGNNReducer(config)
     result = reducer.run()
     print(
-        "Reduction complete. Best genome size: {} species".format(int(result.best_genome.sum()))
+        "Reduction complete. Best genome size: {} species".format(
+            int(result.best_genome.sum())
+        )
     )
 
 


### PR DESCRIPTION
## Summary
- rebuild reduced mechanisms by deep copying species/reactions, reuse a thermal ignition surrogate for baseline solves, and add a robust YAML export fallback.
- sanitize CLI inputs for 1-D/0-D case selection so runs ignore unsupported 0-D cases without aborting.
- extend validation comparisons and plotting helpers to generate overlays, KPI tables, and diagnostics while handling missing data gracefully.

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d9125a6a048328ab0db0e14d3a1961